### PR TITLE
Enable Markdown formatted package long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
     author="Per Voie & Erling Lone",
     description="Library for efficient processing and visualization of time series.",
     long_description=read('README.md'),
+    long_description_content_type="text/markdown",
     license="MIT",
     url="https://github.com/dnvgl/qats",
     download_url="https://pypi.org/project/qats/",


### PR DESCRIPTION
Added `long_description_content_type` to enable PyPi to parse the MarkDown formatted long description.