### PR TITLE
Corrects error in power spectral density estimates.

### DIFF
--- a/qats/signal.py
+++ b/qats/signal.py
@@ -689,7 +689,7 @@ def psd(x, dt, nperseg=None, noverlap=None, detrend='constant', nfft=None):
         nperseg = x.size/4
 
     # estimate psd using welch's definition
-    f, p = welch(x, fs=dt, nperseg=nperseg, noverlap=noverlap, nfft=nfft, detrend=detrend, window='hanning',
+    f, p = welch(x, fs=1./dt, nperseg=nperseg, noverlap=noverlap, nfft=nfft, detrend=detrend, window='hanning',
                  return_onesided=True, scaling='density', axis=-1)
 
     return f, p

--- a/qats/ts.py
+++ b/qats/ts.py
@@ -1049,6 +1049,10 @@ class TimeSeries(object):
             see documentation of TimeSeries.get() method for available options
 
         """
+        # This import registers the 3D projection, but is otherwise unused.
+        # noinspection PyUnresolvedReferences
+        from mpl_toolkits.mplot3d import Axes3D
+
         cycles = self.rfc(**kwargs)
         ranges, means, counts = mesh(cycles, nr=nr, nm=nm)
 

--- a/qats/ts.py
+++ b/qats/ts.py
@@ -918,7 +918,7 @@ class TimeSeries(object):
         t, x = self.get(**kwargs)
 
         plt.figure(1)
-        plt.plot(t, x)
+        plt.plot(t, x, label=self.name)
         plt.xlabel('Time (s)')
         plt.grid()
         plt.legend()
@@ -942,7 +942,7 @@ class TimeSeries(object):
         # dict with TimeSeries objects
         plt.figure(1)
         f, p = self.psd(**kwargs)
-        plt.plot(f, p)
+        plt.plot(f, p, label=self.name)
         plt.xlabel('Frequency (Hz)')
         plt.ylabel('Power spectral density')
         plt.grid()
@@ -980,10 +980,11 @@ class TimeSeries(object):
 
         r, _, c = zip(*cycles)      # unpack cycle range and count, ignore mean value
         dr = r[1] - r[0]            # bar width
-        plt.bar(r, c, dr)
+        plt.bar(r, c, dr, label=self.name)
         plt.xlabel('Cycle range')
         plt.ylabel('Cycle count (-)')
         plt.grid()
+        plt.legend()
         if figurename is not None:
             plt.savefig(figurename)
         else:
@@ -1021,12 +1022,12 @@ class TimeSeries(object):
 
         ranges, means, counts = zip(*cycles)      # unpack cycle range, mean and count
 
-        # the scatter plot
-        plt.scatter(means, ranges, s=[2. * c for c in counts], alpha=0.4)  # double marker size for improved readability
+        # the scatter plot (with double marker size for improved readability)
+        plt.scatter(means, ranges, s=[2. * c for c in counts], alpha=0.4, label=self.name)
         plt.xlabel('Cycle mean')
         plt.ylabel('Cycle range')
         plt.grid()
-
+        plt.legend()
         if figurename is not None:
             plt.savefig(figurename)
         else:
@@ -1057,7 +1058,6 @@ class TimeSeries(object):
         ax.set_xlabel('Cycle mean')
         ax.set_ylabel('Cycle range')
         ax.set_zlabel('Cycle count')
-
         if figurename is not None:
             plt.savefig(figurename)
         else:

--- a/qats/tsdb.py
+++ b/qats/tsdb.py
@@ -708,7 +708,7 @@ class TsDB(object):
         verbose : bool, optional
             Print information
         kwargs : optional
-            see documentation of :meth:`~qats.ts.TimeSeries.get` method for available options
+            see documentation of :meth:`~qats.TimeSeries.get` method for available options
 
         Notes
         -----
@@ -886,7 +886,7 @@ class TsDB(object):
 
         See also
         --------
-        qats.ts.TimeSeries
+        qats.TimeSeries
         geta, getda, getl, getm
         """
         # check that at least one of the required parameters is given,
@@ -952,7 +952,7 @@ class TsDB(object):
         store : bool, optional
             Disable time series storage. Default is to store the time series objects first time it is read.
         kwargs : optional
-            See documentation of :meth:`~qats.ts.TimeSeries.get` method for available options
+            See documentation of :meth:`~qats.TimeSeries.get` method for available options
 
         Returns
         -------
@@ -967,7 +967,7 @@ class TsDB(object):
 
         See also
         --------
-        qats.ts.TimeSeries, qats.ts.TimeSeries.get
+        qats.TimeSeries, qats.TimeSeries.get
         get, getda, getl, getm
         """
         # use self.get() to avoid duplicate code
@@ -985,7 +985,7 @@ class TsDB(object):
         """
         Get dict of TimeSeries objects.
 
-        Note that this method is identical to :meth:`~qats.ts.TimeSeries.getm`.
+        Note that this method is identical to :meth:`~qats.TimeSeries.getm`.
 
         Parameters
         ----------
@@ -1006,7 +1006,7 @@ class TsDB(object):
 
         See also
         --------
-        qats.ts.TimeSeries
+        qats.TimeSeries
         get, geta, getda, getl, getm
         """
         return self.getm(names=names, ind=ind, store=store, fullkey=fullkey)
@@ -1028,7 +1028,7 @@ class TsDB(object):
         fullkey : bool, optional
             Use full key in returned container
         kwargs : optional
-            see documentation of :meth:`~qats.ts.TimeSeries.get` method for available options
+            see documentation of :meth:`~qats.TimeSeries.get` method for available options
 
         Returns
         -------
@@ -1042,7 +1042,7 @@ class TsDB(object):
 
         See also
         --------
-        qats.ts.TimeSeries, qats.ts.TimeSeries.get
+        qats.TimeSeries, qats.TimeSeries.get
         get, geta, getl, getm
         """
         # read time series and put in ordered dictionary (reuse getm() to avoid duplicating code)
@@ -1076,7 +1076,7 @@ class TsDB(object):
 
         See also
         --------
-        qats.ts.TimeSeries
+        qats.TimeSeries
         get, geta, getda, getm
         """
         # read time series and return in list (reuse getm() to avoid duplicating code)
@@ -1113,7 +1113,7 @@ class TsDB(object):
 
         See also
         --------
-        qats.ts.TimeSeries
+        qats.TimeSeries
         get, geta, getda, getl
         """
         # check that non-compatible parameters are not combined
@@ -1397,7 +1397,7 @@ class TsDB(object):
 
         See also
         --------
-        qats.ts.TimeSeries
+        qats.TimeSeries
 
         """
         # todo: add possibility for subplots in plot method. nsub=None (int), sharex=True.
@@ -1440,7 +1440,7 @@ class TsDB(object):
 
         See also
         --------
-        qats.ts.TimeSeries
+        qats.TimeSeries
 
         """
         # dict with TimeSeries objects
@@ -1546,7 +1546,7 @@ class TsDB(object):
 
         See also
         --------
-        qats.ts.TimeSeries
+        qats.TimeSeries
 
         """
         # dict with TimeSeries objects
@@ -1651,7 +1651,7 @@ class TsDB(object):
 
         See also
         --------
-        qats.ts.TimeSeries.stats, qats.ts.TimeSeries.get
+        qats.TimeSeries.stats, qats.TimeSeries.get
 
         Examples
         --------

--- a/test/test_signal.py
+++ b/test/test_signal.py
@@ -4,7 +4,7 @@ Module for testing signal processing functions
 """
 import unittest
 import numpy as np
-from qats.signal import smooth, average_frequency, taper, lowpass, highpass, bandblock, bandpass
+from qats.signal import smooth, average_frequency, taper, lowpass, highpass, bandblock, bandpass, psd
 
 
 class TestSignal(unittest.TestCase):
@@ -85,6 +85,34 @@ class TestSignal(unittest.TestCase):
         # variance of random uniform distributed number is amplitude squared
         # the processes are independent
         self.assertAlmostEqual(np.var(x), 0.5 + 0.1 ** 2., delta=0.001)
+
+    def test_psd_area_moment_0(self):
+        """Check zero area moment of the spectral density."""
+        dt = self.t[1] - self.t[0]
+        f, p = psd(self.x, dt)
+        df = f[1] - f[0]
+        self.assertAlmostEqual(df * np.sum(p), np.var(self.x), delta=1.e-3)
+
+    def test_psd_area_moment_2(self):
+        """Check second area moment of the spectral density."""
+        dt = self.t[1] - self.t[0]
+        f, p = psd(self.x2, dt)
+        df = f[1] - f[0]
+        m0 = df * np.sum(p)
+        m2 = df * np.sum(f ** 2. * p)
+        self.assertAlmostEqual(np.sqrt(m2 / m0), 0.2, delta=1.e-3)
+
+    def test_psd_nyquist_frequency(self):
+        """Check that the maximum psd frequency equals the Nyquist frequency."""
+        dt = self.t[1] - self.t[0]
+        f, _ = psd(self.x, dt)
+        self.assertAlmostEqual(np.max(f), 0.5 * 1. / dt, delta=1.e-6)
+
+    def test_psd_zero_frequency(self):
+        """Check that the maximum psd frequency equals the Nyquist frequency."""
+        dt = self.t[1] - self.t[0]
+        f, _ = psd(self.x, dt)
+        self.assertAlmostEqual(np.min(f), 0., delta=1.e-6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Changes
Changed the sampling frequency `fs` in the [welch function call](https://github.com/dnvgl/qats/blob/3378ea5972f1cd56a23a902397d195f03c0f8db2/qats/signal.py#L692) to `fs=1./dt` instead of `fs=dt` which was wrong.

The error appeared between versions [4.0.0 and 4.1.0](https://github.com/dnvgl/qats/compare/4.0.0...4.1.0). 

## Added
Four new tests on `qats.signal.psd` that would have caught this error.