### PR TITLE
New Qt binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ We apply the *"major.minor.micro"* versioning scheme defined in [PEP 440](https:
 Click link to see all [unreleased] changes to the master branch of the repository. 
 For comparison to specific branches, use the [GitHub compare](https://github.com/dnvgl/qats/compare) page.
 
+### [4.2.0] // 23.09.2019
+
+#### Changes
+Replaced hard dependency on `PyQt5` with `QtPy`, due to `PyQt5`'s strong copyleft GPL license. `QtPy` is a shim over various Qt bindings such as: `PyQt4`, `PyQt5`, `Pyside` and `Pyside2`. The user must now install the preferred binding himself/herself, in order to use the GUI.
+
+Note: If several qt bindings are installed (e.g. `PyQt5` and `Pyside2`), the environmental variable `QT_API` may be used to control which binding is used. See https://pypi.org/project/QtPy/ for details.
+
 ### [4.1.1] // 17.09.2019
 
 #### Fixed
@@ -84,7 +91,8 @@ First proper release to [PyPI](https://pypi.org/project/qats/).
 
 <!-- Links to be defined below here -->
 
-[Unreleased]: https://github.com/dnvgl/qats/compare/4.1.1...HEAD
+[Unreleased]: https://github.com/dnvgl/qats/compare/4.2.0...HEAD
+[4.2.0]: https://github.com/dnvgl/qats/compare/4.1.1...4.2.0
 [4.1.1]: https://github.com/dnvgl/qats/compare/4.0.1...4.1.1
 [4.1.0]: https://github.com/dnvgl/qats/compare/4.0.1...4.1.0
 [4.0.1]: https://github.com/dnvgl/qats/compare/4.0.0...4.0.1

--- a/README.md
+++ b/README.md
@@ -40,13 +40,29 @@ Run the below command in a Python environment to install the latest QATS release
 pip install qats
 ```
 
-Launch the GUI...
+Import qats in your own scripts
+
+```python
+from qats import TsDB, TimeSeries
+```
+
+Note that as of version 4.2.0 you are quite free to choose which [Qt](https://www.qt.io) binding you would like to use for the GUI.
+Either: [https://pypi.org/project/PyQt4/](https://pypi.org/project/PyQt4/), [PyQt5](https://pypi.org/project/PyQt5/),
+[Pyside](https://pypi.org/project/PySide/) or [Pyside2](https://pypi.org/project/PySide2/).
+
+Install the chosen binding (here PyQt5 as an example) 
+
+```console
+pip install pyqt5
+```
+
+..and launch the GUI.
 
 ```console
 qats app
 ```
 
-and create a start menu link which you can even pin to the taskbar to ease access to the QATS GUI.
+Create a start menu link which you can even pin to the taskbar to ease access to the QATS GUI.
 
 ```console
 qats config --link-app

--- a/README.md
+++ b/README.md
@@ -34,35 +34,43 @@ perfect for inspecting, comparing and reporting:
 
 ### Getting started
 
-Run the below command in a Python environment to install the latest QATS release.
+Run the below command in a Python environment to install the latest QATS release:
 
 ```console
 pip install qats
 ```
 
-Import qats in your own scripts
+To upgrade from a previous version, the command is:
+
+```console
+pip install --upgrade qats
+```
+
+You may now import qats in your own scripts:
 
 ```python
 from qats import TsDB, TimeSeries
 ```
 
-Note that as of version 4.2.0 you are quite free to choose which [Qt](https://www.qt.io) binding you would like to use for the GUI.
-Either: [https://pypi.org/project/PyQt4/](https://pypi.org/project/PyQt4/), [PyQt5](https://pypi.org/project/PyQt5/),
-[Pyside](https://pypi.org/project/PySide/) or [Pyside2](https://pypi.org/project/PySide2/).
+... or use the GUI to inspect time series. Note that as of version 4.2.0 you are quite free to choose which 
+[Qt](https://www.qt.io) binding you would like to use for the GUI: [PyQt5](https://pypi.org/project/PyQt5/) or 
+[Pyside2](https://pypi.org/project/PySide2/), or even [PyQt4](https://pypi.org/project/PyQt4/) / 
+[Pyside](https://pypi.org/project/PySide/).
 
-Install the chosen binding (here PyQt5 as an example) 
+Install the chosen binding (here PyQt5 as an example):
 
 ```console
 pip install pyqt5
 ```
 
-..and launch the GUI.
+... and launch the GUI:
 
 ```console
 qats app
 ```
 
-Create a start menu link which you can even pin to the taskbar to ease access to the QATS GUI.
+To create a start menu link, which you can even pin to the taskbar to ease access to the 
+QATS GUI, run the following command:
 
 ```console
 qats config --link-app
@@ -89,13 +97,15 @@ Install Python version 3.6 or later from either https://www.python.org or https:
 
 ### Clone the source code repository
 
-At the desired location run ```git clone https://github.com/dnvgl/qats.git```
+At the desired location, run: 
+
+```git clone https://github.com/dnvgl/qats.git```
 
 ### Installing
 
-To get the development environment running
+To get the development environment running:
 
-.. create an isolated Python environment and activate it,
+... create an isolated Python environment and activate it,
 
 ```console
 python -m venv /path/to/new/virtual/environment
@@ -103,7 +113,7 @@ python -m venv /path/to/new/virtual/environment
 /path/to/new/virtual/environment/Scripts/activate
 ```
 
-.. install the dev dependencies in [requirements.txt](requirements.txt)
+... install the dev dependencies in [requirements.txt](requirements.txt),
 
 ```console
 pip install -r requirements.txt
@@ -115,14 +125,14 @@ pip install -r requirements.txt
 python setup.py develop
 ```
 
-Now you should be able to import the package in the Python console
+You should now be able to import the package in the Python console,
 
 ```python
 import qats
 help(qats)
 ```
 
-.. and the command line interface (CLI).
+... and use the command line interface (CLI).
 
 ```console
 qats -h
@@ -140,7 +150,7 @@ The test automation is configured in the file `tox.ini`.
 
 ### Building the package
 
-Build tarball and wheel distributions by 
+Build tarball and wheel distributions by:
 
 ```console
 python setup.py sdist bdist_wheel

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -30,11 +30,6 @@ example):
 
 Supported qt bindings are: PyQt5, Pyside2, PyQt4 and Pyside.
 
-.. warning::
-    If you install QATS in a Conda environment make sure that the conda-package `pyqt` is not installed in that
-    same environment as that will conflict with `PyQt5` installed from PyPI. `PyQt5` is a dependency of
-    QATS.
-
 Now you should be able to import the package in the Python console
 
 .. code-block:: python

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -11,11 +11,24 @@ You need Python version 3.6 or later. You can find it at https://www.python.org 
 Installation
 ************
 
-Wether you are in a Python virtalenv or a Conda env you install QATS from PyPI as
+.. note::
+    As of version 4.2.0, you must install the desired qt binding yourself (needed for the GUI to work).
+    Supported packages are: PyQt5, Pyside2, PyQt4 and Pyside. See installation instructions below.
+
+Wether you are in a Python virtalenv or a Conda env, QATS is installed from PyPI by using `pip`:
 
 .. code-block:: console
 
     pip install qats
+
+In order to use the GUI, you must also install a Python package with qt bindings (here, `PyQt5` is used as an
+example):
+
+.. code-block::
+
+    pip install pyqt5
+
+Supported qt bindings are: PyQt5, Pyside2, PyQt4 and Pyside.
 
 .. warning::
     If you install QATS in a Conda environment make sure that the conda-package `pyqt` is not installed in that

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -15,7 +15,7 @@ Installation
     As of version 4.2.0, you must install the desired qt binding yourself (needed for the GUI to work).
     Supported packages are: PyQt5, Pyside2, PyQt4 and Pyside. See installation instructions below.
 
-Wether you are in a Python virtalenv or a Conda env, QATS is installed from PyPI by using `pip`:
+QATS is installed from PyPI by using `pip`:
 
 .. code-block:: console
 

--- a/qats/app/exceptions.py
+++ b/qats/app/exceptions.py
@@ -6,7 +6,7 @@ import os
 import sys
 import traceback
 import webbrowser
-from PyQt5.QtWidgets import QMessageBox
+from qtpy.QtWidgets import QMessageBox
 
 
 def handle_exception(exc_type, exc_value, exc_traceback):

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -238,7 +238,7 @@ class Qats(QMainWindow):
 
         # set initial value of time window spin boxes
         self.from_time.setValue(0)
-        self.to_time.setValue(1000000000000)
+        self.to_time.setValue(1000000000)
 
         # mutual exclusive peaks/troughs radio buttons
         minmax_group = QGroupBox("Select statistical quantity")

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -9,9 +9,9 @@ import logging
 import os
 from itertools import cycle
 import numpy as np
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import QMainWindow, QFileDialog, QMessageBox, QWidget, QHBoxLayout, \
+from qtpy.QtCore import *
+from qtpy.QtGui import *
+from qtpy.QtWidgets import QMainWindow, QFileDialog, QMessageBox, QWidget, QHBoxLayout, \
     QListView, QGroupBox, QLabel, QRadioButton, QCheckBox, QDoubleSpinBox, QVBoxLayout, QPushButton, QAction, \
     QLineEdit, QComboBox, QSplitter, QFrame, QTabBar
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
@@ -562,7 +562,7 @@ class Qats(QMainWindow):
             source_index = self.db_proxy_model.mapToSource(proxy_index)
 
             # is this item checked?
-            is_selected = self.db_source_model.data(source_index, Qt.CheckStateRole) == QVariant(Qt.Checked)
+            is_selected = self.db_source_model.data(source_index, Qt.CheckStateRole) != 0
 
             if is_selected:
                 # item path relative to common path in db
@@ -1023,6 +1023,7 @@ class Qats(QMainWindow):
 
             # Execute
             self.threadpool.start(worker)
+
         else:
             # inform user to select at least one time series before plotting
             logging.info("Select at least 1 time series before plotting.")

--- a/qats/app/logger.py
+++ b/qats/app/logger.py
@@ -6,7 +6,7 @@ Module implementing a logger class
 @author: perl
 """
 import logging
-from PyQt5.QtWidgets import QTextBrowser
+from qtpy.QtWidgets import QTextBrowser
 
 
 class QLogger(logging.Handler):

--- a/qats/app/models.py
+++ b/qats/app/models.py
@@ -5,7 +5,7 @@ Module containing models such as item models, proxy models etc tailored for the 
 @author: perl
 """
 
-from PyQt5.QtCore import QSortFilterProxyModel
+from qtpy.QtCore import QSortFilterProxyModel
 
 
 class CustomSortFilterProxyModel(QSortFilterProxyModel):

--- a/qats/app/threading.py
+++ b/qats/app/threading.py
@@ -1,6 +1,6 @@
 import sys
 import traceback
-from PyQt5.QtCore import QRunnable, pyqtSignal, QObject, pyqtSlot
+from qtpy.QtCore import QRunnable, Signal as QSignal, QObject, Slot as QSlot
 
 
 class WorkerSignals(QObject):
@@ -18,9 +18,9 @@ class WorkerSignals(QObject):
     result
         `object` data returned from processing, anything
     """
-    finished = pyqtSignal()
-    error = pyqtSignal(tuple)
-    result = pyqtSignal(object)
+    finished = QSignal()
+    error = QSignal(tuple)
+    result = QSignal(object)
 
 
 class Worker(QRunnable):
@@ -44,7 +44,7 @@ class Worker(QRunnable):
         self.kwargs = kwargs
         self.signals = WorkerSignals()
 
-    @pyqtSlot()
+    @QSlot()
     def run(self):
         """
         Initialise the runner function with passed args, kwargs.

--- a/qats/app/widgets.py
+++ b/qats/app/widgets.py
@@ -5,7 +5,7 @@ Module with custom widgets
 
 @author: perl
 """
-from PyQt5.QtWidgets import QTabWidget
+from qtpy.QtWidgets import QTabWidget
 
 
 class CustomTabWidget (QTabWidget):

--- a/qats/cli.py
+++ b/qats/cli.py
@@ -6,7 +6,7 @@ import os
 import sys
 import argparse
 import sysconfig
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtWidgets import QApplication
 from pkg_resources import resource_filename
 from .app.exceptions import handle_exception
 from .app.gui import Qats, LOGGING_LEVELS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 h5py==2.9.0
-matplotlib==3.0.3
+matplotlib==3.1.1
 numpy==1.16.3
 openpyxl==2.6.2
 pandas==0.24.2
-PyQt5==5.12.1
+QtPy==1.9.0
+pyside2==5.13.1
+PyQt5==5.13.1
 scipy==1.2.1
 setuptools-scm==3.2.0
 wheel==0.33.1

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "scipy>=1,<2",
         "matplotlib>=3,<4",
         "h5py>=2.7,<3",
-        "PyQt5>=5.6,<6",
+        "QtPy>=1,<2",
         "pandas>=0.24,<1",
         "pywin32; platform_system == 'Windows'"
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@
 envlist = py36
 
 [testenv]
-deps =
-
+deps = Pyside2
+setenv =
+    QT_API = pyside2
 commands =
     python -m unittest discover
     qats -h


### PR DESCRIPTION
## Changes
Replaced hard dependency on PyQt5 (GPL licensed) with QtPy, a shim over various Qt bindings such as: PyQt4, PyQt5, Pyside and Pyside2. Now the user may choose and install the preferred binding.

Set the environmental variable `QT_API='pyside2'` to link 'Pyside2' to QATS (QtPy).

## Remaining tasks
Before finishing the PR we have to:
- [x] Update the CLI to inform/prompt user about installing and linking a Qt binding.
- [x] Update README
- [x] Update documentation

Resolves #45 