### PR TITLE
rainflow: (optionally) include endpoints in cycle counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ For comparison to specific branches, use the [GitHub compare](https://github.com
 `.plot_*()` methods of `TimeSeries` and `TsDB` classes (for background and more details, see [issue #55](https://github.com/dnvgl/qats/issues/55)):
 
 - Introduced optional parameter `num`, to control `matplotlib.pyplot` figure number.
-- Introduced optional parameter show (bool), to control whether pyplot.show() is invoked or not.
+- Introduced optional parameter `show` (bool), to control whether `pyplot.show()` is invoked or not.
 - `.plot_cycle_range()`: introduced optional parameter `bw`, to control bar width.
 
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,26 @@ We apply the *"major.minor.micro"* versioning scheme defined in [PEP 440](https:
 Click link to see all [unreleased] changes to the master branch of the repository. 
 For comparison to specific branches, use the [GitHub compare](https://github.com/dnvgl/qats/compare) page.
 
+
+### [4.4.0] // 04.11.2019
+
+#### Added
+
+`qats.fatigue.rainflow` module:
+
+- Introduced a new optional parameter `endpoints` (bool) to functions `reversals()`, `cycles()` and `cycle_counting()`. If set to True, first and last points in series passed are included as cycle start/end points. This is convenient if the series passed is already an array of reversal points, but should in general not be used otherwise. Default is `endpoints=False`, which gives the same behavior as before.
+
+`.plot_*()` methods of `TimeSeries` and `TsDB` classes (for background and more details, see [issue #55](https://github.com/dnvgl/qats/issues/55)):
+
+- Introduced optional parameter `num`, to control `matplotlib.pyplot` figure number.
+- Introduced optional parameter show (bool), to control whether pyplot.show() is invoked or not.
+- `.plot_cycle_range()`: introduced optional parameter `bw`, to control bar width.
+
 #### Fixed
+
 - `TimeSeries.stats()`: `np.nan` is inserted for statistical values that cannot be calculated (e.g. Weibull parameters if fit fails).
 - Desktop application (GUI), statistics tab: fixed issues related to clearing the table, updating when Weibull fit fails and mismatch between values and table heading. For details, see [issue #58](https://github.com/dnvgl/qats/issues/58).
+
 
 ### [4.3.0] // 30.10.2019
 
@@ -37,7 +54,7 @@ Restructured the functions for calculating power spectral density. *Note: The de
 
 ### [4.2.0] // 23.09.2019
 
-#### Changes
+#### Changed
 Replaced hard dependency on `PyQt5` with `QtPy`, due to `PyQt5`'s strong copyleft GPL license. `QtPy` is a shim over various Qt bindings such as: `PyQt4`, `PyQt5`, `Pyside` and `Pyside2`. The user must now install the preferred binding himself/herself, in order to use the GUI.
 
 Note: If several qt bindings are installed (e.g. `PyQt5` and `Pyside2`), the environmental variable `QT_API` may be used to control which binding is used. See https://pypi.org/project/QtPy/ for details.
@@ -107,7 +124,8 @@ First proper release to [PyPI](https://pypi.org/project/qats/).
 
 <!-- Links to be defined below here -->
 
-[Unreleased]: https://github.com/dnvgl/qats/compare/4.3.0...HEAD
+[Unreleased]: https://github.com/dnvgl/qats/compare/4.4.0...HEAD
+[4.4.0]: https://github.com/dnvgl/qats/compare/4.3.0...4.4.0
 [4.3.0]: https://github.com/dnvgl/qats/compare/4.2.0...4.3.0
 [4.2.0]: https://github.com/dnvgl/qats/compare/4.1.1...4.2.0
 [4.1.1]: https://github.com/dnvgl/qats/compare/4.0.1...4.1.1

--- a/qats/fatigue/rainflow.py
+++ b/qats/fatigue/rainflow.py
@@ -19,6 +19,8 @@ def reversals(series, endpoints=False):
         data series
     endpoints : bool, optional
         If True, first and last points in `series` are included. Default is False.
+        Note that in general, inclusion of end points is only relevant if the series passed is already an array of
+        reversal points.
 
     Returns
     -------
@@ -136,7 +138,8 @@ def count_cycles(series, endpoints=False):
         Data series.
     endpoints : bool, optional
         If True, first and last points in `series` are included as cycle start/end points. This is convenient if the
-        series given is already an array of reversal points. Default is False.
+        series given is already an array of reversal points, but should in general not be used otherwise.
+        Default is False.
 
     Returns
     -------

--- a/qats/fatigue/rainflow.py
+++ b/qats/fatigue/rainflow.py
@@ -9,7 +9,7 @@ import numpy as np
 # TODO: Evaluate from-to counting which stores the "orientation" of each cycle. Enables reconstruction of a time history
 
 
-def reversals(series):
+def reversals(series, endpoints=False):
     """
     A generator function which iterates over the reversals in the iterable *series*.
 
@@ -17,6 +17,8 @@ def reversals(series):
     ----------
     series : array_like
         data series
+    endpoints : bool, optional
+        If True, first and last points in `series` are included. Default is False.
 
     Returns
     -------
@@ -26,13 +28,17 @@ def reversals(series):
     Notes
     -----
     Reversals are the points at which the first derivative on the series changes sign. The generator never yields
-    the first and the last points in the series.
+    the first and the last points in the series, unless `endpoints` is set to True (in which case they are always
+    included).
 
     """
     series = iter(series)
 
     x_last, x = next(series), next(series)
     d_last = (x - x_last)
+
+    if endpoints is True:
+        yield x_last
 
     for x_next in series:
         if x_next == x:
@@ -43,8 +49,11 @@ def reversals(series):
         x_last, x = x, x_next
         d_last = d_next
 
+    if endpoints is True:
+        yield x
 
-def cycles(series):
+
+def cycles(series, endpoints=False):
     """
     Find full cycles and half-cycles range and mean value from *series* and count the number of occurrences using the
     Rainflow algorithm.
@@ -53,6 +62,9 @@ def cycles(series):
     ----------
     series : array_like
         data series
+    endpoints : bool, optional
+        If True, first and last points in `series` are included as cycle start/end points. This is convenient if the
+        series given is already an array of reversal points. Default is False.
 
     Returns
     -------
@@ -81,7 +93,7 @@ def cycles(series):
     points = deque()
     full, half = [], []
 
-    for r in reversals(series):
+    for r in reversals(series, endpoints=endpoints):
         points.append(r)
         while len(points) >= 3:
             # Form ranges X and Y from the three most recent points
@@ -114,7 +126,7 @@ def cycles(series):
     return full, half
 
 
-def count_cycles(series):
+def count_cycles(series, endpoints=False):
     """
     Count number of occurrences of cycle range and mean combinations.
 
@@ -122,6 +134,9 @@ def count_cycles(series):
     ----------
     series : array_like
         Data series.
+    endpoints : bool, optional
+        If True, first and last points in `series` are included as cycle start/end points. This is convenient if the
+        series given is already an array of reversal points. Default is False.
 
     Returns
     -------
@@ -155,7 +170,7 @@ def count_cycles(series):
     rainflow.reversals, rainflow.cycles, rainflow.cycle_ranges, rainflow.cycle_means, rainflow.cycle_rangemean
 
     """
-    full, half = cycles(series)
+    full, half = cycles(series, endpoints=endpoints)
 
     # Count cycles
     counts = defaultdict(float)

--- a/qats/ts.py
+++ b/qats/ts.py
@@ -892,7 +892,7 @@ class TimeSeries(object):
         """
         self._t, self.x = self.get(**kwargs)
 
-    def plot(self, figurename=None, **kwargs):
+    def plot(self, figurename=None, show=None, num=1, **kwargs):
         """
         Plot time series trace.
 
@@ -902,6 +902,10 @@ class TimeSeries(object):
             Time series names
         figurename : str, optional
             Save figure to file 'figurename' instead of displaying on screen.
+        show : bool, optional
+            Show figure? Defaults to False if `figurename` is specified, otherwise True.
+        num : int, optional
+            Matplotlib figure number. Defaults to 1.
         kwargs : optional
             See documentation of TimeSeries.get() method for available options
 
@@ -909,17 +913,17 @@ class TimeSeries(object):
         # dict with numpy arrays: time and data
         t, x = self.get(**kwargs)
 
-        plt.figure(1)
+        plt.figure(num=num)
         plt.plot(t, x, label=self.name)
         plt.xlabel('Time (s)')
         plt.grid()
         plt.legend()
         if figurename is not None:
             plt.savefig(figurename)
-        else:
+        if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_psd(self, figurename=None, **kwargs):
+    def plot_psd(self, figurename=None, show=None, num=1, **kwargs):
         """
         Plot time series power spectral density.
 
@@ -927,12 +931,16 @@ class TimeSeries(object):
         ----------
         figurename : str, optional
             Save figure to file 'figurename' instead of displaying on screen.
+        show : bool, optional
+            Show figure? Defaults to False if `figurename` is specified, otherwise True.
+        num : int, optional
+            Matplotlib figure number. Defaults to 1.
         kwargs : optional
             see documentation of TimeSeries.psd() method for available options
 
         """
         # dict with TimeSeries objects
-        plt.figure(1)
+        plt.figure(num=num)
         f, p = self.psd(**kwargs)
         plt.plot(f, p, label=self.name)
         plt.xlabel('Frequency (Hz)')
@@ -941,10 +949,10 @@ class TimeSeries(object):
         plt.legend()
         if figurename is not None:
             plt.savefig(figurename)
-        else:
+        if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_cycle_range(self, n=200, w=None, figurename=None, **kwargs):
+    def plot_cycle_range(self, n=200, w=None, figurename=None, show=None, num=1, **kwargs):
         """
         Plot cycle range versus number of occurrences.
 
@@ -956,6 +964,10 @@ class TimeSeries(object):
             Group by cycle range in *w* wide equidistant bins. Overrides *n*.
         figurename : str, optional
             Save figure to file 'figurename' instead of displaying on screen.
+        show : bool, optional
+            Show figure? Defaults to False if `figurename` is specified, otherwise True.
+        num : int, optional
+            Matplotlib figure number. Defaults to 1.
         kwargs : optional
             see documentation of TimeSeries.rfc() method for available options
 
@@ -972,6 +984,7 @@ class TimeSeries(object):
 
         r, _, c = zip(*cycles)      # unpack cycle range and count, ignore mean value
         dr = r[1] - r[0]            # bar width
+        plt.figure(num=num)
         plt.bar(r, c, dr, label=self.name)
         plt.xlabel('Cycle range')
         plt.ylabel('Cycle count (-)')
@@ -979,10 +992,10 @@ class TimeSeries(object):
         plt.legend()
         if figurename is not None:
             plt.savefig(figurename)
-        else:
+        if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_cycle_rangemean(self, n=None, w=None, figurename=None, **kwargs):
+    def plot_cycle_rangemean(self, n=None, w=None, figurename=None, show=None, num=1, **kwargs):
         """
         Plot cycle range-mean versus number of occurrences.
 
@@ -994,6 +1007,10 @@ class TimeSeries(object):
             Group by cycle range in *w* wide equidistant bins. Overrides *n*.
         figurename : str, optional
             Save figure to file 'figurename' instead of displaying on screen.
+        show : bool, optional
+            Show figure? Defaults to False if `figurename` is specified, otherwise True.
+        num : int, optional
+            Matplotlib figure number. Defaults to 1.
         kwargs : optional
             see documentation of TimeSeries.rfc() method for available options
 
@@ -1015,6 +1032,7 @@ class TimeSeries(object):
         ranges, means, counts = zip(*cycles)      # unpack cycle range, mean and count
 
         # the scatter plot (with double marker size for improved readability)
+        plt.figure(num=num)
         plt.scatter(means, ranges, s=[2. * c for c in counts], alpha=0.4, label=self.name)
         plt.xlabel('Cycle mean')
         plt.ylabel('Cycle range')
@@ -1022,10 +1040,10 @@ class TimeSeries(object):
         plt.legend()
         if figurename is not None:
             plt.savefig(figurename)
-        else:
+        if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_cycle_rangemean3d(self, nr=100, nm=100, figurename=None, **kwargs):
+    def plot_cycle_rangemean3d(self, nr=100, nm=100, figurename=None, show=None, num=1, **kwargs):
         """
         Plot cycle range-mean versus number of occurrences as 3D surface.
 
@@ -1037,6 +1055,10 @@ class TimeSeries(object):
             Group by cycle mean in *nm* equidistant bins.
         figurename : str, optional
             Save figure to file 'figurename' instead of displaying on screen.
+        show : bool, optional
+            Show figure? Defaults to False if `figurename` is specified, otherwise True.
+        num : int, optional
+            Matplotlib figure number. Defaults to 1.
         kwargs : optional
             see documentation of TimeSeries.get() method for available options
 
@@ -1048,7 +1070,7 @@ class TimeSeries(object):
         cycles = self.rfc(**kwargs)
         ranges, means, counts = mesh(cycles, nr=nr, nm=nm)
 
-        fig = plt.figure()
+        fig = plt.figure(num=num)
         ax = fig.gca(projection='3d')
         ax.plot_surface(means, ranges, counts, cmap=cm.coolwarm)
         ax.set_xlabel('Cycle mean')
@@ -1056,7 +1078,7 @@ class TimeSeries(object):
         ax.set_zlabel('Cycle count')
         if figurename is not None:
             plt.savefig(figurename)
-        else:
+        if show is True or (show is None and figurename is None):
             plt.show()
 
     def psd(self, nperseg=None, noverlap=None, detrend='constant', nfft=None, normalize=False, **kwargs):

--- a/qats/ts.py
+++ b/qats/ts.py
@@ -952,7 +952,7 @@ class TimeSeries(object):
         if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_cycle_range(self, n=200, w=None, figurename=None, show=None, num=1, **kwargs):
+    def plot_cycle_range(self, n=200, w=None, bw=1., figurename=None, show=None, num=1, **kwargs):
         """
         Plot cycle range versus number of occurrences.
 
@@ -962,6 +962,8 @@ class TimeSeries(object):
             Group by cycle range in *n* equidistant bins.
         w : float, optional
             Group by cycle range in *w* wide equidistant bins. Overrides *n*.
+        bw : float, optional
+            Bar width, expressed as ratio of bin width.
         figurename : str, optional
             Save figure to file 'figurename' instead of displaying on screen.
         show : bool, optional
@@ -982,10 +984,10 @@ class TimeSeries(object):
                                                    "be different from None"
         cycles = rebin_cycles(cycles, binby='range', n=n, w=w)
 
-        r, _, c = zip(*cycles)      # unpack cycle range and count, ignore mean value
-        dr = r[1] - r[0]            # bar width
+        r, _, c = zip(*cycles)  # unpack cycle range and count, ignore mean value
+        dr = r[1] - r[0]        # bin width, used as basis for bar width
         plt.figure(num=num)
-        plt.bar(r, c, dr, label=self.name)
+        plt.bar(r, c, dr * bw, label=self.name)
         plt.xlabel('Cycle range')
         plt.ylabel('Cycle count (-)')
         plt.grid()

--- a/qats/tsdb.py
+++ b/qats/tsdb.py
@@ -1375,7 +1375,7 @@ class TsDB(object):
                 print("Loaded %d records from file '%s'." % (len(names), thefile))
                 print('\n'.join(names))
 
-    def plot(self, names=None, figurename=None, store=True, **kwargs):
+    def plot(self, names=None, figurename=None, store=True, show=None, num=1, **kwargs):
         """
         Plot time series traces.
 
@@ -1387,6 +1387,10 @@ class TsDB(object):
             Save figure to file 'figurename' instead of displaying on screen.
         store : bool, optional
             Disable time series storage. Default is to store the time series objects first time it is read.
+        show : bool, optional
+            Show figure? Defaults to False if `figurename` is specified, otherwise True.
+        num : int, optional
+            Matplotlib figure number. Defaults to 1.
         kwargs : optional
             See documentation of TimeSeries.get() method for available options
 
@@ -1405,7 +1409,7 @@ class TsDB(object):
         # dict with numpy arrays: time and data
         container = self.getda(names=names, store=store, **kwargs)
 
-        plt.figure(1)
+        plt.figure(num=num)
         for k, v in container.items():
             label = k  # todo: more readable label, e.g. remove commonpath
             plt.plot(v[0], v[1], label=label)
@@ -1415,10 +1419,10 @@ class TsDB(object):
         plt.legend()
         if figurename is not None:
             plt.savefig(figurename)
-        else:
+        if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_psd(self, names=None, figurename=None, store=True, **kwargs):
+    def plot_psd(self, names=None, figurename=None, store=True, show=None, num=1, **kwargs):
         """
         Plot time series power spectral density.
 
@@ -1430,6 +1434,10 @@ class TsDB(object):
             Save figure to file 'figurename' instead of displaying on screen.
         store : bool, optional
             Disable time series storage. Default is to store the time series objects first time it is read.
+        show : bool, optional
+            Show figure? Defaults to False if `figurename` is specified, otherwise True.
+        num : int, optional
+            Matplotlib figure number. Defaults to 1.
         kwargs : optional
             see documentation of TimeSeries.get() method for available options
 
@@ -1446,7 +1454,7 @@ class TsDB(object):
         # dict with TimeSeries objects
         container = self.getm(names=names, store=store)
 
-        plt.figure(1)
+        plt.figure(num=num)
         for k, v in container.items():
             f, p = v.psd(**kwargs)
             plt.plot(f, p, label=k)
@@ -1457,10 +1465,10 @@ class TsDB(object):
         plt.legend()
         if figurename is not None:
             plt.savefig(figurename)
-        else:
+        if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_cycle_range(self, names=None, n=200, w=None, figurename=None, store=True, **kwargs):
+    def plot_cycle_range(self, names=None, n=200, w=None, figurename=None, store=True, show=None, num=1, **kwargs):
         """
         Plot cycle range versus number of occurrences.
 
@@ -1476,6 +1484,10 @@ class TsDB(object):
             Save figure to file 'figurename' instead of displaying on screen.
         store : bool, optional
             Disable time series storage. Default is to store the time series objects first time it is read.
+        show : bool, optional
+            Show figure? Defaults to False if `figurename` is specified, otherwise True.
+        num : int, optional
+            Matplotlib figure number. Defaults to 1.
         kwargs : optional
             see documentation of TimeSeries.get() method for available options
 
@@ -1496,7 +1508,7 @@ class TsDB(object):
         assert (n is not None) or (w is not None), "Cycles must be rebinned for this plot - either 'n' or 'w' must " \
                                                    "be different from None"
 
-        plt.figure(1)
+        plt.figure(num=num)
         for k, v in container.items():
             # extract cycles
             cycles = v.rfc(**kwargs)
@@ -1514,10 +1526,10 @@ class TsDB(object):
         plt.legend()
         if figurename is not None:
             plt.savefig(figurename)
-        else:
+        if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_cycle_rangemean(self, names=None, n=None, w=None, figurename=None, store=True, **kwargs):
+    def plot_cycle_rangemean(self, names=None, n=None, w=None, figurename=None, store=True, show=True, num=1, **kwargs):
         """
         Plot cycle range-mean versus number of occurrences.
 
@@ -1533,6 +1545,10 @@ class TsDB(object):
             Save figure to file 'figurename' instead of displaying on screen.
         store : bool, optional
             Disable time series storage. Default is to store the time series objects first time it is read.
+        show : bool, optional
+            Show figure? Defaults to False if `figurename` is specified, otherwise True.
+        num : int, optional
+            Matplotlib figure number. Defaults to 1.
         kwargs : optional
             see documentation of TimeSeries.get() method for available options
 
@@ -1552,7 +1568,7 @@ class TsDB(object):
         # dict with TimeSeries objects
         container = self.getm(names=names, store=store)
 
-        plt.figure(1)
+        plt.figure(num=num)
         for k, v in container.items():
             # extract cycles
             cycles = v.rfc(**kwargs)
@@ -1570,7 +1586,7 @@ class TsDB(object):
         plt.legend()
         if figurename is not None:
             plt.savefig(figurename)
-        else:
+        if show is True or (show is None and figurename is None):
             plt.show()
 
     def rename(self, name, newname):

--- a/qats/tsdb.py
+++ b/qats/tsdb.py
@@ -1375,7 +1375,7 @@ class TsDB(object):
                 print("Loaded %d records from file '%s'." % (len(names), thefile))
                 print('\n'.join(names))
 
-    def plot(self, names=None, figurename=None, store=True, show=None, num=1, **kwargs):
+    def plot(self, names=None, figurename=None, show=None, num=1, store=True, **kwargs):
         """
         Plot time series traces.
 
@@ -1385,12 +1385,12 @@ class TsDB(object):
             Time series names
         figurename : str, optional
             Save figure to file 'figurename' instead of displaying on screen.
-        store : bool, optional
-            Disable time series storage. Default is to store the time series objects first time it is read.
         show : bool, optional
             Show figure? Defaults to False if `figurename` is specified, otherwise True.
         num : int, optional
             Matplotlib figure number. Defaults to 1.
+        store : bool, optional
+            Disable time series storage. Default is to store the time series objects first time it is read.
         kwargs : optional
             See documentation of TimeSeries.get() method for available options
 
@@ -1422,7 +1422,7 @@ class TsDB(object):
         if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_psd(self, names=None, figurename=None, store=True, show=None, num=1, **kwargs):
+    def plot_psd(self, names=None, figurename=None, show=None, num=1, store=True, **kwargs):
         """
         Plot time series power spectral density.
 
@@ -1432,12 +1432,12 @@ class TsDB(object):
             Time series names
         figurename : str, optional
             Save figure to file 'figurename' instead of displaying on screen.
-        store : bool, optional
-            Disable time series storage. Default is to store the time series objects first time it is read.
         show : bool, optional
             Show figure? Defaults to False if `figurename` is specified, otherwise True.
         num : int, optional
             Matplotlib figure number. Defaults to 1.
+        store : bool, optional
+            Disable time series storage. Default is to store the time series objects first time it is read.
         kwargs : optional
             see documentation of TimeSeries.get() method for available options
 
@@ -1468,7 +1468,8 @@ class TsDB(object):
         if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_cycle_range(self, names=None, n=200, w=None, figurename=None, store=True, show=None, num=1, **kwargs):
+    def plot_cycle_range(self, names=None, n=200, w=None, bw=1., figurename=None, show=None, num=1, store=True,
+                         **kwargs):
         """
         Plot cycle range versus number of occurrences.
 
@@ -1480,14 +1481,16 @@ class TsDB(object):
             Group by cycle range in *n* equidistant bins.
         w : float, optional
             Group by cycle range in *w* wide equidistant bins. Overrides *n*.
+        bw : float, optional
+            Bar width, expressed as ratio of bin width.
         figurename : str, optional
             Save figure to file 'figurename' instead of displaying on screen.
-        store : bool, optional
-            Disable time series storage. Default is to store the time series objects first time it is read.
         show : bool, optional
             Show figure? Defaults to False if `figurename` is specified, otherwise True.
         num : int, optional
             Matplotlib figure number. Defaults to 1.
+        store : bool, optional
+            Disable time series storage. Default is to store the time series objects first time it is read.
         kwargs : optional
             see documentation of TimeSeries.get() method for available options
 
@@ -1516,9 +1519,9 @@ class TsDB(object):
             # rebin cycles
             cycles = rebin_cycles(cycles, binby='range', n=n, w=w)
 
-            r, _, c = zip(*cycles)   # unpack range and count pairs, ignore mean value
-            dr = r[1] - r[0]     # bar width
-            plt.bar(r, c, dr, label=k, alpha=0.4)
+            r, _, c = zip(*cycles)  # unpack range and count pairs, ignore mean value
+            dr = r[1] - r[0]        # bin width, used as basis for bar width
+            plt.bar(r, c, dr * bw, label=k, alpha=0.4)
 
         plt.xlabel('Cycle range')
         plt.ylabel('Cycle count (-)')
@@ -1529,7 +1532,7 @@ class TsDB(object):
         if show is True or (show is None and figurename is None):
             plt.show()
 
-    def plot_cycle_rangemean(self, names=None, n=None, w=None, figurename=None, store=True, show=True, num=1, **kwargs):
+    def plot_cycle_rangemean(self, names=None, n=None, w=None, figurename=None, show=True, num=1, store=True, **kwargs):
         """
         Plot cycle range-mean versus number of occurrences.
 
@@ -1543,12 +1546,12 @@ class TsDB(object):
             Group by cycle range in *w* wide equidistant bins. Overrides *n*.
         figurename : str, optional
             Save figure to file 'figurename' instead of displaying on screen.
-        store : bool, optional
-            Disable time series storage. Default is to store the time series objects first time it is read.
         show : bool, optional
             Show figure? Defaults to False if `figurename` is specified, otherwise True.
         num : int, optional
             Matplotlib figure number. Defaults to 1.
+        store : bool, optional
+            Disable time series storage. Default is to store the time series objects first time it is read.
         kwargs : optional
             see documentation of TimeSeries.get() method for available options
 


### PR DESCRIPTION
#### Changed

`qats.fatigue.rainflow`: introduced a new optional parameter `endpoints` (bool) to functions `reversals()`, `cycles()` and `cycle_counting()`. If set to True, first and last points in series passed are included as cycle start/end points. This is convenient if the series passed is already an array of reversal points, but should in general not be used otherwise. Default is `endpoints=False`, which gives the same behavior as before.

Closes #53, closes #55.