### PR TITLE
gui: fix issues with statistical table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ We apply the *"major.minor.micro"* versioning scheme defined in [PEP 440](https:
 Click link to see all [unreleased] changes to the master branch of the repository. 
 For comparison to specific branches, use the [GitHub compare](https://github.com/dnvgl/qats/compare) page.
 
+#### Fixed
+- `TimeSeries.stats()`: `np.nan` is inserted for statistical values that cannot be calculated (e.g. Weibull parameters if fit fails).
+- Desktop application (GUI), statistics tab: fixed issues related to clearing the table, updating when Weibull fit fails and mismatch between values and table heading. For details, see [issue #58](https://github.com/dnvgl/qats/issues/58).
+
 ### [4.3.0] // 30.10.2019
 
 #### Added

--- a/qats/app/funcs.py
+++ b/qats/app/funcs.py
@@ -128,75 +128,8 @@ def calculate_stats(container, twin, fargs, minima=False):
     dict
         Filtered and windowed time series and peaks/throughs
     """
-    container_out = dict()
-
-    for name, ts in container.items():
-        _ = ts.stats(twin=twin, filterargs=fargs, statsdur=10800., quantiles=(0.37, 0.57, 0.9), minima=minima)
-        mean = _.get("mean")
-        std = _.get("std")
-        skew = _.get("skew")
-        kurt = _.get("kurt")
-        min = _.get("min")
-        max = _.get("max")
-        tz = _.get("tz")
-        wloc = _.get("wloc")
-        wscale = _.get("wscale")
-        wshape = _.get("wshape")
-        gloc = _.get("gloc")
-        gscale = _.get("gscale")
-        p_37 = _.get("p_37.00")
-        p_57 = _.get("p_57.00")
-        p_90 = _.get("p_90.00")
-
-        container_out[name] = dict(mean=mean, std=std, skew=skew, kurt=kurt, min=min, max=max, tz=tz, wloc=wloc,
-                                   wscale=wscale, wshape=wshape, gloc=gloc, gscale=gscale, p_37=p_37, p_57=p_57,
-                                   p_90=p_90)
-
-    return container_out
-
-
-def calculate_weibull_fit(container, twin, fargs, minima=False):
-    """
-    Calculate time series maxima and fit Weibull distribution
-
-    Parameters
-    ----------
-    container : dict
-        TimeSeries objects
-    twin : tuple
-        Time window. Time series are cropped to time window before extracting maxima.
-    fargs : tuple
-        Filter arguments. Time series are filtered before extracting maxima.
-    minima : bool, optional
-        Fit to sample of minima instead of maxima. The sample is multiplied by -1 prior to parameter estimation.
-
-    Returns
-    -------
-    dict
-        Sample and fitted weibull distribution parameters
-    """
-    container_out = dict()
-
-    for name, ts in container.items():
-        if not minima:
-            # global maxima
-            m = ts.maxima(twin=twin, rettime=False, filterargs=fargs)
-            f = 1
-        else:
-            # global minima
-            m = ts.minima(twin=twin, rettime=False, filterargs=fargs)
-            f = -1     # flip sample for weibull fit
-
-        if (m is not None) and (len(m) > 1):
-            # fit weibull distribution parameter
-            a, b, c = weibull_pwm(f * m)
-        else:
-            # no sample or too small sample for estimation of parameters
-            m = a = b = c = None
-
-        container_out[name] = dict(sample=m, loc=a, scale=b, shape=c, minima=minima)
-
-    return container_out
+    return {name: ts.stats(twin=twin, filterargs=fargs, statsdur=10800., quantiles=(0.37, 0.57, 0.9),
+                           is_minima=minima, include_sample=True) for name, ts in container.items()}
 
 
 def calculate_gumbel_fit(container, twin, fargs, minima=False):

--- a/qats/app/funcs.py
+++ b/qats/app/funcs.py
@@ -108,7 +108,7 @@ def calculate_trace(container, twin, fargs):
     return container_out
 
 
-def calculate_stats(container, twin, fargs):
+def calculate_stats(container, twin, fargs, minima=False):
     """
     Calculate time series statistics
 
@@ -120,6 +120,8 @@ def calculate_stats(container, twin, fargs):
         Time window. Time series are cropped to time window before extracting maxima.
     fargs : tuple
         Filter arguments. Time series are filtered before extracting maxima.
+    minima : bool, optional
+        Fit to sample of minima instead of maxima. The sample is multiplied by -1 prior to parameter estimation.
 
     Returns
     -------
@@ -129,7 +131,7 @@ def calculate_stats(container, twin, fargs):
     container_out = dict()
 
     for name, ts in container.items():
-        _ = ts.stats(twin=twin, filterargs=fargs, statsdur=10800., quantiles=(0.37, 0.57, 0.9))
+        _ = ts.stats(twin=twin, filterargs=fargs, statsdur=10800., quantiles=(0.37, 0.57, 0.9), minima=minima)
         mean = _.get("mean")
         std = _.get("std")
         skew = _.get("skew")

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -1225,6 +1225,7 @@ class Qats(QMainWindow):
         nperseg = self.psd_nperseg()
         psdnorm = self.psd_normalized()
         nbins = self.rfc_nbins()
+        minima_stats = self.minima.isChecked()
 
         # start calculation of filtered and windows time series trace
         worker = Worker(calculate_trace, container, twin, fargs)
@@ -1233,7 +1234,7 @@ class Qats(QMainWindow):
         self.threadpool.start(worker)
 
         # start calculations of statistics
-        worker = Worker(calculate_stats, container, twin, fargs)
+        worker = Worker(calculate_stats, container, twin, fargs, minima=minima_stats)
         worker.signals.error.connect(self.log_thread_exception)
         worker.signals.result.connect(self.tabulate_stats)
         self.threadpool.start(worker)
@@ -1245,7 +1246,7 @@ class Qats(QMainWindow):
         self.threadpool.start(worker)
 
         # start calculations of weibull
-        worker = Worker(calculate_weibull_fit, container, twin, fargs, self.minima.isChecked())
+        worker = Worker(calculate_weibull_fit, container, twin, fargs, minima=minima_stats)
         worker.signals.error.connect(self.log_thread_exception)
         worker.signals.result.connect(self.plot_weibull)
         self.threadpool.start(worker)

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -1121,16 +1121,16 @@ class Qats(QMainWindow):
         self.stats_table.setRowCount(0)
         self.stats_table.setColumnCount(16)
         self.stats_table.setAlternatingRowColors(True)
-        self.stats_table.setHorizontalHeaderLabels(["Name", "Mean", "Min.", "Max.", "Std.", "Skew.", "Kurt.", "Tz",
+        self.stats_table.setHorizontalHeaderLabels(["Name", "Min.", "Max.", "Mean", "Std.", "Skew.", "Kurt.", "Tz",
                                                     "Wloc", "Wscale", "Wshape", "Gloc", "Gscale", "P .37", "P .57",
                                                     "P .90"])
         self.stats_table.horizontalHeaderItem(0).setToolTip('Time series name.')
-        self.stats_table.horizontalHeaderItem(1).setToolTip('Mean/average.')
-        self.stats_table.horizontalHeaderItem(2).setToolTip('Unbiased standard deviation.')
-        self.stats_table.horizontalHeaderItem(3).setToolTip('Skewness.')
-        self.stats_table.horizontalHeaderItem(4).setToolTip('Kurtosis, Pearson’s definition (3.0 --> normal).')
-        self.stats_table.horizontalHeaderItem(5).setToolTip('Sample minimum.')
-        self.stats_table.horizontalHeaderItem(6).setToolTip('Sample maximum.')
+        self.stats_table.horizontalHeaderItem(1).setToolTip('Sample minimum.')
+        self.stats_table.horizontalHeaderItem(2).setToolTip('Sample maximum.')
+        self.stats_table.horizontalHeaderItem(3).setToolTip('Mean/average.')
+        self.stats_table.horizontalHeaderItem(4).setToolTip('Unbiased standard deviation.')
+        self.stats_table.horizontalHeaderItem(5).setToolTip('Skewness.')
+        self.stats_table.horizontalHeaderItem(6).setToolTip('Kurtosis, Pearson’s definition (3.0 --> normal).')
         self.stats_table.horizontalHeaderItem(7).setToolTip('Average mean crossing period (s).')
         self.stats_table.horizontalHeaderItem(8).setToolTip('Weibull location parameter in distribution fitted to'
                                                             'sample maxima/minima.')
@@ -1289,34 +1289,18 @@ class Qats(QMainWindow):
         self.reset_stats_table()
         self.stats_table.setRowCount(max(len(container), 50))
         for i, (name, data) in enumerate(container.items()):
-            # mean = data.get("mean")
-            # std = data.get("std")
-            # skew = data.get("skew")
-            # kurt = data.get("kurt")
-            # minx = data.get("min")
-            # maxx = data.get("max")
-            # tz = data.get("tz")
-            # wloc = data.get("wloc")
-            # wscale = data.get("wscale")
-            # wshape = data.get("wshape")
-            # gloc = data.get("gloc")
-            # gscale = data.get("gscale")
-            # p_37 = data.get("p_37")
-            # p_57 = data.get("p_57")
-            # p_90 = data.get("p_90")
-
             cell = QTableWidgetItem(name)
             cell.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
             cell.setToolTip(name)
             self.stats_table.setItem(i, 0, cell)
 
-            for j, key in enumerate(["mean", "std", "skew", "kurt", "min", "max", "tz", "wloc", "wscale", "wshape",
+            for j, key in enumerate(["min", "max", "mean", "std", "skew", "kurt", "tz", "wloc", "wscale", "wshape",
                                      "gloc", "gscale", "p_37", "p_57", "p_90"]):
                 value = data.get(key, np.nan)
                 try:
                     cell = QTableWidgetItem(f"{value:12.5g}")
                 except TypeError:
-                    cell = QTableWidgetItem("NaN")
+                    cell = QTableWidgetItem("nan")
                 cell.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
                 self.stats_table.setItem(i, j + 1, cell)
 

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -1121,7 +1121,7 @@ class Qats(QMainWindow):
         self.stats_table.setRowCount(0)
         self.stats_table.setColumnCount(16)
         self.stats_table.setAlternatingRowColors(True)
-        self.stats_table.setHorizontalHeaderLabels(["Name", "Mean", "Std.", "Skew.", "Kurt.", "Min.", "Max.", "Tz",
+        self.stats_table.setHorizontalHeaderLabels(["Name", "Mean", "Min.", "Max.", "Std.", "Skew.", "Kurt.", "Tz",
                                                     "Wloc", "Wscale", "Wshape", "Gloc", "Gscale", "P .37", "P .57",
                                                     "P .90"])
         self.stats_table.horizontalHeaderItem(0).setToolTip('Time series name.')

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -1126,11 +1126,11 @@ class Qats(QMainWindow):
                                                     "P .90"])
         self.stats_table.horizontalHeaderItem(0).setToolTip('Time series name.')
         self.stats_table.horizontalHeaderItem(1).setToolTip('Mean/average.')
-        self.stats_table.horizontalHeaderItem(2).setToolTip('Sample minimum.')
-        self.stats_table.horizontalHeaderItem(3).setToolTip('Sample maximum.')
-        self.stats_table.horizontalHeaderItem(4).setToolTip('Unbiased standard deviation.')
-        self.stats_table.horizontalHeaderItem(5).setToolTip('Skewness.')
-        self.stats_table.horizontalHeaderItem(6).setToolTip('Kurtosis, Pearson’s definition (3.0 --> normal).')
+        self.stats_table.horizontalHeaderItem(2).setToolTip('Unbiased standard deviation.')
+        self.stats_table.horizontalHeaderItem(3).setToolTip('Skewness.')
+        self.stats_table.horizontalHeaderItem(4).setToolTip('Kurtosis, Pearson’s definition (3.0 --> normal).')
+        self.stats_table.horizontalHeaderItem(5).setToolTip('Sample minimum.')
+        self.stats_table.horizontalHeaderItem(6).setToolTip('Sample maximum.')
         self.stats_table.horizontalHeaderItem(7).setToolTip('Average mean crossing period (s).')
         self.stats_table.horizontalHeaderItem(8).setToolTip('Weibull location parameter in distribution fitted to'
                                                             'sample maxima/minima.')
@@ -1310,7 +1310,7 @@ class Qats(QMainWindow):
             cell.setToolTip(name)
             self.stats_table.setItem(i, 0, cell)
 
-            for j, value in enumerate([mean, minx, maxx, std, skew, kurt, tz, wloc, wscale, wshape, gloc, gscale,
+            for j, value in enumerate([mean, std, skew, kurt, minx, maxx, tz, wloc, wscale, wshape, gloc, gscale,
                                        p_37, p_57, p_90]):
                 cell = QTableWidgetItem(f"{value:12.5g}")
                 cell.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -1297,10 +1297,7 @@ class Qats(QMainWindow):
             for j, key in enumerate(["min", "max", "mean", "std", "skew", "kurt", "tz", "wloc", "wscale", "wshape",
                                      "gloc", "gscale", "p_37", "p_57", "p_90"]):
                 value = data.get(key, np.nan)
-                try:
-                    cell = QTableWidgetItem(f"{value:12.5g}")
-                except TypeError:
-                    cell = QTableWidgetItem("nan")
+                cell = QTableWidgetItem(f"{value:12.5g}")   # works also with nan values
                 cell.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
                 self.stats_table.setItem(i, j + 1, cell)
 

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -653,7 +653,7 @@ class Qats(QMainWindow):
         """
         Plot checked data series when pressing the 'show' button.
         """
-
+        # self.reset_stats_table()  # debug
         # list of selected series
         selected_series = self.selected_series()
 
@@ -1289,30 +1289,34 @@ class Qats(QMainWindow):
         self.reset_stats_table()
         self.stats_table.setRowCount(max(len(container), 50))
         for i, (name, data) in enumerate(container.items()):
-            mean = data.get("mean")
-            std = data.get("std")
-            skew = data.get("skew")
-            kurt = data.get("kurt")
-            minx = data.get("min")
-            maxx = data.get("max")
-            tz = data.get("tz")
-            wloc = data.get("wloc")
-            wscale = data.get("wscale")
-            wshape = data.get("wshape")
-            gloc = data.get("gloc")
-            gscale = data.get("gscale")
-            p_37 = data.get("p_37")
-            p_57 = data.get("p_57")
-            p_90 = data.get("p_90")
+            # mean = data.get("mean")
+            # std = data.get("std")
+            # skew = data.get("skew")
+            # kurt = data.get("kurt")
+            # minx = data.get("min")
+            # maxx = data.get("max")
+            # tz = data.get("tz")
+            # wloc = data.get("wloc")
+            # wscale = data.get("wscale")
+            # wshape = data.get("wshape")
+            # gloc = data.get("gloc")
+            # gscale = data.get("gscale")
+            # p_37 = data.get("p_37")
+            # p_57 = data.get("p_57")
+            # p_90 = data.get("p_90")
 
             cell = QTableWidgetItem(name)
             cell.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
             cell.setToolTip(name)
             self.stats_table.setItem(i, 0, cell)
 
-            for j, value in enumerate([mean, std, skew, kurt, minx, maxx, tz, wloc, wscale, wshape, gloc, gscale,
-                                       p_37, p_57, p_90]):
-                cell = QTableWidgetItem(f"{value:12.5g}")
+            for j, key in enumerate(["mean", "std", "skew", "kurt", "min", "max", "tz", "wloc", "wscale", "wshape",
+                                     "gloc", "gscale", "p_37", "p_57", "p_90"]):
+                value = data.get(key, np.nan)
+                try:
+                    cell = QTableWidgetItem(f"{value:12.5g}")
+                except TypeError:
+                    cell = QTableWidgetItem("NaN")
                 cell.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
                 self.stats_table.setItem(i, j + 1, cell)
 

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -1132,12 +1132,12 @@ class Qats(QMainWindow):
         self.stats_table.horizontalHeaderItem(5).setToolTip('Skewness.')
         self.stats_table.horizontalHeaderItem(6).setToolTip('Kurtosis, Pearson’s definition (3.0 --> normal).')
         self.stats_table.horizontalHeaderItem(7).setToolTip('Average mean crossing period (s).')
-        self.stats_table.horizontalHeaderItem(8).setToolTip('Weibull location parameter in distribution fitted to'
-                                                            'sample maxima/minima.')
-        self.stats_table.horizontalHeaderItem(9).setToolTip('Weibull scale parameter in distribution fitted to'
-                                                            'sample maxima/minima.')
-        self.stats_table.horizontalHeaderItem(10).setToolTip('Weibull shape parameter in distribution fitted to'
-                                                             'sample maxima/minima.')
+        self.stats_table.horizontalHeaderItem(8).setToolTip('Weibull location parameter in distribution fitted to\n'
+                                                            'sample maxima or -1 multiplied with the sample minima.')
+        self.stats_table.horizontalHeaderItem(9).setToolTip('Weibull scale parameter in distribution fitted to\n'
+                                                            'sample maxima or -1 multiplied with the sample minima.')
+        self.stats_table.horizontalHeaderItem(10).setToolTip('Weibull shape parameter in distribution fitted to\n'
+                                                             'sample maxima or -1 multiplied with the sample minima.')
         self.stats_table.horizontalHeaderItem(11).setToolTip('Gumbel location parameter in sample extreme distribution'
                                                              'derived from sample maxima/minima distribution.')
         self.stats_table.horizontalHeaderItem(12).setToolTip('Gumbel location parameter in sample extreme distribution'

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -617,6 +617,7 @@ class Qats(QMainWindow):
         self.db_common_path = ""
         self.db_source_model.clear()
         self.reset_axes()
+        self.reset_stats_table()
         logging.info("Cleared all time series from database...")
         self.set_status()
 

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -35,7 +35,6 @@ from .funcs import (
     calculate_trace,
     calculate_psd,
     calculate_rfc,
-    calculate_weibull_fit,
     calculate_gumbel_fit,
     calculate_stats
 )
@@ -948,10 +947,10 @@ class Qats(QMainWindow):
         # draw
         for name, value in container.items():
             x = value.get("sample")
-            loc = value.get("loc")
-            scale = value.get("scale")
-            shape = value.get("shape")
-            is_minima = value.get("minima")
+            loc = value.get("wloc")
+            scale = value.get("wscale")
+            shape = value.get("wshape")
+            is_minima = value.get("is_minima")
 
             if x is None:
                 # skip
@@ -1234,18 +1233,13 @@ class Qats(QMainWindow):
         worker = Worker(calculate_stats, container, twin, fargs, minima=minima_stats)
         worker.signals.error.connect(self.log_thread_exception)
         worker.signals.result.connect(self.tabulate_stats)
+        worker.signals.result.connect(self.plot_weibull)
         self.threadpool.start(worker)
 
         # start calculations of psd
         worker = Worker(calculate_psd, container, twin, fargs, nperseg, psdnorm)
         worker.signals.error.connect(self.log_thread_exception)
         worker.signals.result.connect(self.plot_psd)
-        self.threadpool.start(worker)
-
-        # start calculations of weibull
-        worker = Worker(calculate_weibull_fit, container, twin, fargs, minima=minima_stats)
-        worker.signals.error.connect(self.log_thread_exception)
-        worker.signals.result.connect(self.plot_weibull)
         self.threadpool.start(worker)
 
         # start calculations of rfc
@@ -1292,7 +1286,7 @@ class Qats(QMainWindow):
             self.stats_table.setItem(i, 0, cell)
 
             for j, key in enumerate(["min", "max", "mean", "std", "skew", "kurt", "tz", "wloc", "wscale", "wshape",
-                                     "gloc", "gscale", "p_37", "p_57", "p_90"]):
+                                     "gloc", "gscale", "p_37.00", "p_57.00", "p_90.00"]):
                 value = data.get(key, np.nan)
                 cell = QTableWidgetItem(f"{value:12.5g}")   # works also with nan values
                 cell.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -976,9 +976,6 @@ class Qats(QMainWindow):
                 logging.warning("Invalid sample for time series '%s'. Cannot fit Weibull distribution." % name)
 
             else:
-                logging.info(f"Fitted Weibull distribution to {txt} sample of {x.size} from '{name}'. "
-                             f"(location, scale, shape) = ({loc}, {scale}, {shape})")
-
                 # normalized quantiles from fitted distribution (inside if-statement to avoid log(negative_num)
                 q_norm_fitted = np.log(q_fitted)
 

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -653,7 +653,7 @@ class Qats(QMainWindow):
         """
         Plot checked data series when pressing the 'show' button.
         """
-        # self.reset_stats_table()  # debug
+        self.reset_stats_table()  # TODO: Rework the gui logic and implement an overall reseti()
         # list of selected series
         selected_series = self.selected_series()
 
@@ -1287,7 +1287,6 @@ class Qats(QMainWindow):
         container : dict
             Time series statistics
         """
-        self.reset_stats_table()
         self.stats_table.setRowCount(max(len(container), 50))
         for i, (name, data) in enumerate(container.items()):
             cell = QTableWidgetItem(name)

--- a/qats/stats/gumbel.py
+++ b/qats/stats/gumbel.py
@@ -79,6 +79,8 @@ class Gumbel(object):
     """
 
     def __init__(self, loc, scale, data=None):
+        assert loc is not None, "Location parameter must be finite."
+        assert scale is not None and scale > 0, "Scale parameter must be finit and larger than 0."
         self.loc = loc
         self.scale = scale
 

--- a/qats/ts.py
+++ b/qats/ts.py
@@ -1252,7 +1252,7 @@ class TimeSeries(object):
             self._t += delta
             self._dtg_time = None  # reset, no need to initiate new array until requested
 
-    def stats(self, statsdur=None, quantiles=None, **kwargs):
+    def stats(self, statsdur=10800., quantiles=(0.37, 0.57, 0.9), **kwargs):
         """
         Returns dictionary with time series properties and statistics
 
@@ -1260,9 +1260,9 @@ class TimeSeries(object):
         ----------
         statsdur : float
             Duration in seconds for estimation of extreme value distribution (Gumbel) from peak distribution (Weibull).
-            Default is 3 hours.
+            Default is 10800 seconds (3 hours).
         quantiles : tuple, optional
-            Quantiles in the Gumbel distribution used for extreme value estimation
+            Quantiles in the Gumbel distribution used for extreme value estimation, defaults to (0.37, 0.57, 0.90).
         kwargs
             Optional parameters passed to TimeSeries.get()
 
@@ -1316,60 +1316,46 @@ class TimeSeries(object):
 
         >>> stats = ts.stats(twin=(500., 1e12))
         """
-        # handle defaults
-        if not statsdur:
-            statsdur = 10800.
-
-        if not quantiles:
-            quantiles = (0.37, 0.57, 0.9)
-
         # get time series as array
         t, x = self.get(**kwargs)
 
-        # find global maxima, estimate weibull and gumbel parameters
-        maxima = find_maxima(x)
+        try:
+            tz = 1. / average_frequency(t, x)
+        except IndexError:
+            # too few maxima, tz may not calculated (keep it as None)
+            tz = np.nan
 
-        wloc = wscale = wshape = gloc = gscale = tz = None
-        if maxima is not None:
+        # find global maxima
+        maxima = find_maxima(x)
+        if np.size(maxima) <= 1:
+            wloc, wscale, wshape, gloc, gscale = np.nan
+        else:
+            wloc, wscale, wshape = pwm(maxima)
+            n = round(statsdur / (t[-1] - t[0]) * np.size(maxima))
             try:
-                tz = 1. / average_frequency(t, x)
-            except IndexError:
-                # too few maxima, tz may not calculated (keep it as None)
-                pass
-            try:
-                wloc, wscale, wshape = pwm(maxima)
-                nmax = maxima.size
-                n = round(statsdur / (t[-1] - t[0]) * nmax)
                 gloc, gscale = weibull2gumbel(wloc, wscale, wshape, n)
-            except ZeroDivisionError:
-                # Weibull fit failed -> let parameters stay None
-                # todo: if weibull2gumbel fails, is it handled by current try-except statement?
-                pass
+            except (AssertionError, ZeroDivisionError) as e:
+                # invalid distribution parameters or bad combinations
+                gloc, gscale = np.nan
+
+            try:
+                g = Gumbel(loc=gloc, scale=gscale)
+            except AssertionError as e:
+                # invalid distribution parameters
+                values = np.nan * np.ones(np.shape(quantiles))
+            else:
+                values = g.invcdf(p=quantiles)
+            finally:
+                pvalues = {f"p_{100 * q:.2f}": v for q, v in zip(quantiles, values)}
 
         # establish output dictionary
         d = OrderedDict(
             start=t[0], end=t[-1], duration=t[-1] - t[0], dtavg=np.mean(np.diff(t)),
             mean=x.mean(), std=tstd(x), skew=skew(x, bias=False),
             kurt=kurtosis(x, fisher=False, bias=False), min=x.min(), max=x.max(), tz=tz,
-            wloc=wloc, wscale=wscale, wshape=wshape, gloc=gloc, gscale=gscale
+            wloc=wloc, wscale=wscale, wshape=wshape, gloc=gloc, gscale=gscale,
+            **pvalues
         )
-
-        # if requested, estimate extreme values
-        if quantiles is not None:
-            if gloc is None:
-                # quantiles may not be calculated -> set to None
-                values = np.array([None] * len(quantiles))
-            else:
-                g = Gumbel(loc=gloc, scale=gscale)
-                try:
-                    values = g.invcdf(p=quantiles)
-                except AssertionError:
-                    # return none for invalid combinations of distribution parameters
-                    values = np.array([None] * len(quantiles))
-
-            for q, v in zip(quantiles, values):
-                d["p_%.2f" % (100 * q)] = v
-
         return d
 
     def std(self, **kwargs):

--- a/qats/ts.py
+++ b/qats/ts.py
@@ -1329,6 +1329,7 @@ class TimeSeries(object):
         maxima = find_maxima(x)
         if np.size(maxima) <= 1:
             wloc, wscale, wshape, gloc, gscale = np.nan
+            pvalues = {f"p_{100 * q:.2f}": np.nan for q in quantiles}
         else:
             wloc, wscale, wshape = pwm(maxima)
             n = round(statsdur / (t[-1] - t[0]) * np.size(maxima))

--- a/qats/ts.py
+++ b/qats/ts.py
@@ -1340,6 +1340,9 @@ class TimeSeries(object):
             pvalues = {f"p_{100 * q:.2f}": np.nan for q in quantiles}
         else:
             wloc, wscale, wshape = pwm(mx)
+            if any(np.isnan([wloc, wscale, wshape])):
+                # force all parameters to nan if one (typically scale or shape) is
+                wloc = wscale = wshape = np.nan
             n = round(statsdur / (t[-1] - t[0]) * np.size(mx))
             try:
                 gloc, gscale = weibull2gumbel(wloc, wscale, wshape, n)

--- a/qats/ts.py
+++ b/qats/ts.py
@@ -1252,7 +1252,7 @@ class TimeSeries(object):
             self._t += delta
             self._dtg_time = None  # reset, no need to initiate new array until requested
 
-    def stats(self, statsdur=10800., quantiles=(0.37, 0.57, 0.9), minima=False, **kwargs):
+    def stats(self, statsdur=10800., quantiles=(0.37, 0.57, 0.9), is_minima=False, include_sample=False, **kwargs):
         """
         Returns dictionary with time series properties and statistics
 
@@ -1263,8 +1263,10 @@ class TimeSeries(object):
             Default is 10800 seconds (3 hours).
         quantiles : tuple, optional
             Quantiles in the Gumbel distribution used for extreme value estimation, defaults to (0.37, 0.57, 0.90).
-        minima : bool, optional
+        is_minima : bool, optional
             Fit to sample of minima instead of maxima. The sample is multiplied by -1 prior to parameter estimation.
+        include_sample : bool, optional
+            Return sample of maxima or minima (minima=True).
         kwargs
             Optional parameters passed to TimeSeries.get()
 
@@ -1272,7 +1274,6 @@ class TimeSeries(object):
         -------
         OrderedDict
             Time series statistics (for details, see Notes below).
-
 
         Notes
         -----
@@ -1328,7 +1329,7 @@ class TimeSeries(object):
             tz = np.nan
 
         # find global maxima or minima
-        if not minima:
+        if not is_minima:
             f = 1.
         else:
             f = -1.
@@ -1361,8 +1362,8 @@ class TimeSeries(object):
             start=t[0], end=t[-1], duration=t[-1] - t[0], dtavg=np.mean(np.diff(t)),
             mean=x.mean(), std=tstd(x), skew=skew(x, bias=False),
             kurt=kurtosis(x, fisher=False, bias=False), min=x.min(), max=x.max(), tz=tz,
-            wloc=wloc, wscale=wscale, wshape=wshape, gloc=gloc, gscale=gscale,
-            **pvalues
+            wloc=wloc, wscale=wscale, wshape=wshape, gloc=gloc, gscale=gscale, is_minima=is_minima,
+            sample=f * mx if include_sample else None, **pvalues
         )
         return d
 


### PR DESCRIPTION
Fix issues with statistical table:

- [x] The sequence of numbers does not match the sequence of headings
- [x] The table doesn't clear when Ctrl+Del is pressed
- [x] The table doesn't update at all when Weibull fitting on one of the selected time series fails
- [x] The other statistical values should by presented even if the Weibull fitting fails. The P .XX could just display NaN 

Fixes #58.