### PR TITLE
Clear the logger and display full time series path in GUI.

### DIFF
--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -54,7 +54,6 @@ ICON_FILE = resource_filename("qats.app", "qats.ico")
 
 # TODO: New method that generalize threading
 # TODO: Explore how to create consecutive threads without handshake in main loop
-# todo: settings on file menu: nperseg= and detrend= for welch psd, Hz, rad/s or s for filters
 # todo: add technical guidance and result interpretation to help menu, link docs website
 # todo: add 'export' option to file menu: response statistics summary (mean, std, skew, kurt, tz, weibull distributions,
 #  gumbel distributions etc.)
@@ -409,20 +408,25 @@ class Qats(QMainWindow):
         help_menu = self.menu_bar.addMenu("&Help")
 
         # create File menu and actions
-        import_action = QAction("&Import from file", self)
+        import_action = QAction("Import from file", self)
         import_action.setShortcut("Ctrl+I")
         import_action.setStatusTip("Import time series from file")
         import_action.triggered.connect(self.on_import)
 
-        export_action = QAction("&Export to file", self)
+        export_action = QAction("Export to file", self)
         export_action.setShortcut("Ctrl+E")
         export_action.setStatusTip("Export time series to file")
         export_action.triggered.connect(self.on_export)
 
-        clear_action = QAction("&Clear", self)
+        clear_action = QAction("Clear", self)
         clear_action.setShortcut("Ctrl+Del")
         clear_action.setStatusTip("Clear all time series from database")
         clear_action.triggered.connect(self.on_clear)
+
+        clear_log_action = QAction("Clear logger", self)
+        clear_log_action.setShortcut("Ctrl+Shift+Del")
+        clear_log_action.setStatusTip("Clear logger widget")
+        clear_log_action.triggered.connect(self.on_clear_logger)
 
         settings_action = QAction("Settings", self)
         settings_action.setStatusTip("Configure application settings")
@@ -446,6 +450,7 @@ class Qats(QMainWindow):
         file_menu.addAction(import_action)
         file_menu.addAction(export_action)
         file_menu.addAction(clear_action)
+        file_menu.addAction(clear_log_action)
         file_menu.addAction(settings_action)
         file_menu.addSeparator()
         file_menu.addAction(quit_action)
@@ -619,6 +624,10 @@ class Qats(QMainWindow):
         self.reset_stats_table()
         logging.info("Cleared all time series from database...")
         self.set_status()
+
+    def on_clear_logger(self):
+        """Clears logger widget."""
+        self.logger.widget.setText("")
 
     def on_create_gumbel_plot(self):
         """

--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -202,7 +202,6 @@ class Qats(QMainWindow):
 
         # initiate time series data base and checkable model and view with filter
         self.db = TsDB()
-        self.db_common_path = ""
         self.db_source_model = QStandardItemModel()
         self.db_proxy_model = CustomSortFilterProxyModel()
         self.db_proxy_model.setDynamicSortFilter(True)
@@ -618,7 +617,6 @@ class Qats(QMainWindow):
         Clear all time series from database
         """
         self.db.clear(names="*", display=False)
-        self.db_common_path = ""
         self.db_source_model.clear()
         self.reset_axes()
         self.reset_stats_table()
@@ -1208,7 +1206,7 @@ class Qats(QMainWindow):
                 rpath = self.db_source_model.data(source_index)
 
                 # join with common path and add to list of checked items
-                selected_items.append(os.path.join(self.db_common_path, rpath))
+                selected_items.append(os.path.join(self.db.common, rpath))
 
         return selected_items
 
@@ -1328,11 +1326,9 @@ class Qats(QMainWindow):
             item = QStandardItem(name)
             item.setCheckState(Qt.Unchecked)
             item.setCheckable(True)
-            item.setToolTip(os.path.join(self.db_common_path, name))
+            item.setToolTip(os.path.join(self.db.common, name))
             self.db_source_model.appendRow(item)
 
-        # common path of all time series id in db
-        self.db_common_path = self.db.common
         self.set_status()
 
 


### PR DESCRIPTION
## Summary

## Fixed
A bug that caused the time series tooltip to only display the time series' relative path.

### Added
File menu action that clears the logger widget. Hot key `Ctrl+Shift+Del`.

Resolves #60