### PR TITLE
sima .h5 reader: minor bug fix

### DIFF
--- a/qats/readers/sima_h5.py
+++ b/qats/readers/sima_h5.py
@@ -142,7 +142,7 @@ def read_data(path, names=None, verbose=False):
                 dt = timeinfo["dt"]
                 t_end = t_start + (nt-1) * dt
                 timearr, step = np.linspace(t_start, t_end, nt, retstep=True)
-                if not dt == step:
+                if not np.isclose(dt, step):  # dt == step:
                     raise Exception("unexpected error: `dt` should be %s but is %s" % (dt, step))
 
             # todo: expand when _get_h5_timearray_info() has been expanded


### PR DESCRIPTION
The time step of the created time array is now checked towards the specified time step with a (very small) tolerance. Previously, the generated time step was required to exactly match the specified one, but in certain cases this failed due to numpy precision.