### PR TITLE
Support for reading witurb key-files (key_<>_witurb.txt) exported from SIMA/RIFLEX version >=4.20

### DIFF
--- a/data/key_sima_witurb.txt
+++ b/data/key_sima_witurb.txt
@@ -1,0 +1,39 @@
+' 
+'   R I F L E X  -  KEY FILE
+'   ------------------------
+' 
+' 
+'   This key-file describes the contents of : sima_witurb.bin
+'   The format of sima_witurb.bin is BINARY
+'   with numbers stored as real single precision (4 bytes)
+'   The file sima_witurb.bin contains time series of wind turbine results
+'   The wind turbine results are stored in columns on sima_witurb.bin
+'
+'  column   wind     contents     unit      contents
+'    no    turbine  abbrivated              descriptive text
+       1     -      FORTRAN       -         FORTRAN specific data - IGNORE
+       2     -      Time          s         Time                                                    
+       3  NREL5MW   RotorSpeed    deg/s     Rotor speed                                             
+       4  NREL5MW   GenSpeed_LP   rpm       Generator speed (LP-filtered)                           
+       5  NREL5MW   GenTorq       kNm       Mechanical generator torque on LSS                      
+       6  NREL5MW   GenPwr        kW        Electrical generator output                             
+       7  NREL5MW   Azimuth       deg       Azimuth angle blade 1                                   
+       8  NREL5MW   WiVel_x       m/s       Incoming wind speed X-dir in shaft system               
+       9  NREL5MW   WiVel_y       m/s       Incoming wind speed Y-dir in shaft system               
+      10  NREL5MW   WiVel_z       m/s       Incoming wind speed Z-dir in shaft system               
+      11  NREL5MW   Fx            kN        Aero force X-dir in shaft system                        
+      12  NREL5MW   Fy            kN        Aero force Y-dir in shaft system                        
+      13  NREL5MW   Fz            kN        Aero force Z-dir in shaft system                        
+      14  NREL5MW   Mx            kNm       Aero moment around X-axis in shaft system               
+      15  NREL5MW   My            kNm       Aero moment around Y-axis in shaft system               
+      16  NREL5MW   Mz            kNm       Aero moment around Z-axis in shaft system               
+      17  NREL5MW   BlPitch1      deg       Pitch angle blade 1, Line: bl1foil                      
+      18  NREL5MW   BlPitch2      deg       Pitch angle blade 2, Line: bl2foil                      
+      19  NREL5MW   BlPitch3      deg       Pitch angle blade 3, Line: bl3foil                      
+      20  NREL5MW   BlDefl_IP1    m         Tip In-Plane deflection     blade 1, Line: bl1foil      
+      21  NREL5MW   BlDefl_OoP1   m         Tip Out-of-Plane deflection blade 1, Line: bl1foil      
+      22  NREL5MW   BlDefl_IP2    m         Tip In-Plane deflection     blade 2, Line: bl2foil      
+      23  NREL5MW   BlDefl_OoP2   m         Tip Out-of-Plane deflection blade 2, Line: bl2foil      
+      24  NREL5MW   BlDefl_IP3    m         Tip In-Plane deflection     blade 3, Line: bl3foil      
+      25  NREL5MW   BlDefl_OoP3   m         Tip Out-of-Plane deflection blade 3, Line: bl3foil      
+      26     -      FORTRAN       -         FORTRAN specific data - IGNORE

--- a/qats/io/sima.py
+++ b/qats/io/sima.py
@@ -11,7 +11,8 @@ from scipy.interpolate import interp1d
 
 def read_sima_wind_names(path):
     """
-    Read time seires names from key-files associated with "wind".bin time-series files exported from SIMA/RIFLEF Dynmod.
+    Read time series names from key-files associated with '<>_witurb.bin' and '<>_blresp.bin' time-series files
+    exported from SIMA/RIFLEF Dynmod.
 
     Parameters
     ----------
@@ -31,10 +32,27 @@ def read_sima_wind_names(path):
     # Extract storage info lines
     p = re.compile(r'ignore*')
     key_lines = [li for li in lines if not li.startswith("'") and not p.search(li.lower())]
-    keys = [lo.split()[1] for lo in key_lines]
 
-    # remove time instance from line
-    keys = keys[1:]
+    # for each row, split into columns (space-separated) and keep first three
+    rows = [lo.split(maxsplit=3)[:3] for lo in key_lines]
+
+    # check which column 'Time' is in
+    # note:
+    #   idx_time is 1 for the witurb format exported by RIFLEX version <4.20
+    #   idx_time is 2 for the witurb format exported by RIFLEX version >=4.20
+    idx_time = rows[0].index('Time')
+
+    # pop first row (the one with 'Time')
+    _ = rows.pop(0)
+
+    # extract keys according inferred file format
+    if idx_time == 1:
+        # SIMA/RIFLEX version <4.20: only keys, no wind turbine name
+        keys = [row[1] for row in rows]
+    else:  # idx_time == 2:
+        # SIMA/RIFLEX version >=4.20: wind turbine name in second
+        keys = [row[1] + '_' + row[2] for row in rows]
+
     return keys
 
 

--- a/test/test_readers.py
+++ b/test/test_readers.py
@@ -29,6 +29,7 @@ class TestAllReaders(unittest.TestCase):
             ("n_elmtra.bin", 162),
             ("wt_blresp.bin", 21),
             ("wt_witurb.bin", 23),
+            ("sima_witurb.bin", 23),
             # direct access files
             ("mooring.ts", 14),
             ("simo_p.ts", 22),


### PR DESCRIPTION
Add support for reading wind turbine key-files (`key_<>_witurb.txt`) exported from SIMA/RIFLEX version >=4.20 (where wind turbine name is included in a column to the left of time series name).

Fixes #97 