### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,27 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    # minimum supported Python version
+    python: "3.7"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/source/conf.py
+  fail_on_warning: true
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   # install requirements first, then qats
+   install:
+     - requirements: requirements.txt
+     - method: pip
+       path: .


### PR DESCRIPTION
Added specification for Read the Docs build (`.readthedocs.yaml` ) in accordance with https://docs.readthedocs.io/en/stable/config-file/v2.html