### PR TITLE
GUI bug fixes

### DIFF
--- a/qats/app/gui.py
+++ b/qats/app/gui.py
@@ -762,13 +762,14 @@ class Qats(QMainWindow):
         # file save dialogue
         dlg = QFileDialog()
         dlg.setWindowIcon(self.icon)
-        options = dlg.Options()
+        # options = dlg.Options()  # raises expection in qt6 (pyside6) -- probably not needed 
+        dlg.setViewMode(QFileDialog.Detail) # https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QFileDialog.html
 
         name, _ = dlg.getSaveFileName(dlg, "Export time series to file", "",
                                       "Direct access file (*.ts);;"
                                       "ASCII file with header (*.dat);;"
                                       "SIMA H5 file (*.h5);;"
-                                      "All Files (*)", options=options)
+                                      "All Files (*)")  # , options=options)
 
         # get list of selected time series
         keys = self.selected_series()
@@ -799,7 +800,8 @@ class Qats(QMainWindow):
         """
         dlg = QFileDialog()
         dlg.setWindowIcon(self.icon)
-        options = dlg.Options()
+        # options = dlg.Options()  # raises expection in qt6 (pyside6) -- probably not needed 
+        dlg.setViewMode(QFileDialog.Detail) # https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QFileDialog.html
         files, _ = dlg.getOpenFileNames(dlg, "Load time series files", "",
                                         "Direct access files (*.ts);;"
                                         "SIMO S2X direct access files with info array (*.tda);;"
@@ -810,7 +812,7 @@ class Qats(QMainWindow):
                                         "SIMA H5 files (*.h5);;"
                                         "CSV file with header (*.csv);;"
                                         "Technical Data Management Streaming files (*.tdms);;"
-                                        "All Files (*)", options=options)
+                                        "All Files (*)")  #, options=options)
 
         # load files into db and update application model and view
         self.load_files(files)
@@ -1396,7 +1398,7 @@ class Qats(QMainWindow):
         # fill item model with time series by unique id (common path is removed)
         names = self.db.list(names="*", relative=True, display=False)
         self.db_source_model.clear()    # clear before re-adding
-
+        # quickfix for Wildcard issue (#119): replace '\' by '/' 
         for name in names:
             # set each item as unchecked initially
             item = QStandardItem(name)


### PR DESCRIPTION
Fixes #119.
Fixes #117 (dirty quickfix).

Tasks:

- [ ] **[gui]** Fix bug where Import/Export dialogue causes GUI to crash.
- [ ] **[gui]** Quickfix for text filter Wildcard issue when backslash (`\`) in name (typically because multiple files loaded).