### PR TITLE
Add python 3.13 support (+ minor docstring improvements)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       # https://stackoverflow.com/questions/75549995/why-do-the-pyside6-qt-modules-cause-tox-to-fail-during-a-github-action
     - name: Install missing libraries on GitHub agent

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ purposes. See deployment for notes on how to deploy the project on a live system
 
 ### Prerequisites
 
-Install Python version 3.8 or later from either https://www.python.org or https://www.anaconda.com.
+Install Python from https://www.python.org or https://www.anaconda.com. 
 
 Install Poetry with [the official installer](https://python-poetry.org/docs/#installing-with-the-official-installer).
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -6,10 +6,8 @@ Getting started
 Prerequisites
 *************
 
-You need Python version 3.8 or later. Versions up to and including 3.11 are tested, version 3.12 is not tested on deployment 
-with Github Actions but successfully tested locally.
-
-You can install Python from https://www.python.org or https://www.anaconda.com.
+You need Python, which may be installed from for instance https://www.python.org or https://www.anaconda.com.
+If not sure about which version to use, see supported python versions on https://pypi.org/project/qats/.
 
 Installation
 ************

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,10 +51,25 @@ Python version support
 
 .. QATS currently supports Python version 3.8 and later. Note that version 3.12 is not properly tested but should work.
 
-QATS currently supports Python version 3.8+. 
+.. QATS currently supports Python version 3.8+. 
+
+QATS aims to support Python versions in accordance with the official `Status of Python versions <https://devguide.python.org/versions>`_ (that is, versions with status **security** and **bugfix**).
+
+The Python versions suported by the latest version of QATS are: 
+
+.. image:: https://img.shields.io/pypi/pyversions/qats
+    :target: https://pypi.org/project/qats/
 
 .. note::
-    Python version <=3.11 is recommended, as version 3.12 is not yet formally tested.
+
+   The Python version support for a specific version of QATS is best seen from the metadata on `PyPi/qats <https://pypi.org/project/qats/>`_. 
+
+
+.. .. image:: https://img.shields.io/pypi/pyversions/qats
+..     :target: https://pypi.org/project/qats/
+
+.. .. note::
+..     Python version <=3.11 is recommended, as version 3.12 is not yet formally tested.
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,14 +31,26 @@ name = "pypi-public"
 url = "https://pypi.org/simple/"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<3.13"
-h5py = ">=3.5.0"
+python = ">=3.8.1,<3.14"
+# h5py = ">=3.5.0"
+h5py = [
+    {version = ">=3.5.0", python = "<3.13"},
+    {version = ">=3.12.1", python = ">=3.13"}
+]
+contourpy = [  # dependency of h5py, automatic version fails when installing for python 3.13
+    {version = ">=1.0.1", python = "<3.13"},
+    {version = ">=1.3.1", python = ">=3.13"},
+]
 pymatreader = ">=0.0.24"
-matplotlib = ">=3.3.3"
+matplotlib = [
+    {version = ">=3.3.3", python = "<3.13"},
+    {version = ">=3.9.1", python = ">=3.13"}
+]
 nptdms = ">=1.1.0"
 numpy = [
     {version = ">=1.21.6", python = "<3.12"},
-    {version = ">=1.26.0", python = ">=3.12"}
+    {version = ">=1.26.0", python = ">=3.12,<3.13"},
+    {version = ">=2.1.0", python = ">=3.13"}
 ]
 openpyxl = ">=3.0.5"
 pandas = [
@@ -50,10 +62,17 @@ pandas = [
 qtpy = ">=1.9.0"
 scipy = [
     {version = ">=1.9.0", python = "<3.12"},
-    {version = ">=1.11.1", python = ">=3.12"}
+    {version = ">=1.11.1", python = ">=3.12,<3.13"},
+    {version = ">=1.14.1", python = ">=3.13"}
 ]
-pywin32 = {version = "^306", markers = "platform_system == 'Windows'"} # MUST check the appropriate constraint
-pyside6 = "^6.6.0"
+pywin32 = [ # MUST check the appropriate constraint
+    {version = "^306", markers = "platform_system == 'Windows'", python = "<3.13"},
+    {version = "^308", markers = "platform_system == 'Windows'", python = ">=3.13"},
+ ] 
+pyside6 = [
+    {version = ">=6.6.0", python = "<3.13"},
+    {version = ">=6.8.1", python = ">=3.13"}
+]
 importlib-resources = "*"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,14 @@ pywin32 = [ # MUST check the appropriate constraint
     {version = "^308", markers = "platform_system == 'Windows'", python = ">=3.13"},
  ] 
 pyside6 = [
-    {version = ">=6.6.0", python = "<3.13"},
-    {version = ">=6.8.1", python = ">=3.13"}
+    # temporary fix: avoid pyside6 version 6.8.1.1, which misses it companion shiboken6 6.8.1.1 on pypi
+    # see issue 134, https://github.com/dnvgl/qats/issues/134
+    # may allow for version >=6.8.1 again when this has been fixed on pyside/shiboken side, 
+    #   e.g.:
+    #       {version = "">=6.6.0,<6.9", python = "<3.13"},
+    #       {version = "~=6.8.1", python = ">3.13"}
+    {version = ">=6.6.0,<=6.8.1", python = "<3.13"},
+    {version = "6.8.1", python = ">=3.13"}
 ]
 importlib-resources = "*"
 

--- a/qats/fatigue/rainflow.py
+++ b/qats/fatigue/rainflow.py
@@ -185,7 +185,7 @@ def count_cycles(series, endpoints=False):
 
     See Also
     --------
-    reversals, cycles
+    reversals, cycles, qats.signal.find_reversals
 
     """
     full, half = cycles(series, endpoints=endpoints)

--- a/qats/signal.py
+++ b/qats/signal.py
@@ -630,6 +630,8 @@ def find_reversals(x) -> Tuple[np.ndarray, np.ndarray]:
     """
     Return reversals (signal turning points).
 
+    .. versionadded :: 5.2.0
+
     Parameters
     ----------
     x : array
@@ -642,30 +644,32 @@ def find_reversals(x) -> Tuple[np.ndarray, np.ndarray]:
     array
         Indices of reversals.
 
+        
     Notes
     -----
-    .. versionadded :: 5.2.0
-
+    
     This function provides quick identification of signal reversals (turning points), as an alternative
-    to `qats.fatigue.rainflow.reversals()` which is slower for large signal arrays. Note that if the 
+    to ``qats.fatigue.rainflow.reversals()`` which is slower for large signal arrays. Note that if the 
     signal includes oscillations with high frequency compared to the frequency oscillations (e.g., due
     to noise in the signal causing), the present function may in some cases include some very local 
-    turning points that are not identified by `qats.fatigue.rainflow.reversals()`. However, when the 
-    turning points obtained from `find_reversals()` are passed through `reversals()` 
-    (with `endpoints=True`), the resulting array will normally be the same as if the signal itself was 
-    passed through `reversals()`.
+    turning points that are not identified by ``qats.fatigue.rainflow.reversals()``. However, when the 
+    turning points obtained from ``find_reversals()`` are passed through ``reversals()`` 
+    (with ``endpoints=True``), the resulting array will normally be the same as if the signal itself was 
+    passed through ``reversals()``.
     
     Specifically, the following two code lines will **not** necessarily produce identical arrays:
+
     >>> from qats.fatigue.rainflow import reversals
     >>> rev1 = np.array(list(reversals(x)))
     >>> rev2, _ = find_reversals(x)
 
-    ... but the following code lines will normally produce `rev3` identical to `rev1` above:
+    ... but the following code lines will normally produce ``rev3`` identical to ``rev1`` above:
+
     >>> rev3 = np.array(list(reversals(rev2, endpoints=True)))
 
     Examples
     --------
-    Extract reversals (turning points) from the time series signal `x`:
+    Extract reversals (turning points) from the time series signal ``x``:
 
     >>> rev, _ = find_reversals(x)
 
@@ -673,13 +677,15 @@ def find_reversals(x) -> Tuple[np.ndarray, np.ndarray]:
 
     >>> rev, indices = find_reversals(x)
 
-    Use `find_reversals()` to speed up cycle counting:
+    Use ``find_reversals()`` to speed up cycle counting:
+    
     >>> from qats.fatigue.rainflow import count_cycles
     >>> rev, _ = find_reversals(x)
     >>> cycles = count_cycles(rev, endpoints=True)
     
     For large arrays, the latter example is practically equivalent to (but faster than)
     the following code:
+
     >>> cycles = count_cycles(x)
     """
     # local maxima and minima (all peaks, both positive and negative)

--- a/qats/stats/gumbel.py
+++ b/qats/stats/gumbel.py
@@ -825,24 +825,20 @@ def pwm(x):
 
         Notes
         -----
-        The probability weighted moment Mljk is defined by Greenwood and others (1979)
-
-        .. math::
+        The probability weighted moment Mljk is defined by Greenwood and others (1979)::
 
             M_{l,j,k} = E[X^l F^j (1-F)^k]
 
-        , where X(F) is the inverse form of the distribution and F is the cumulative distribution function.
+        where X(F) is the inverse form of the distribution and F is the cumulative distribution function.
         When j=k=0 and l is a non-negative integer then M_{l,0,0} represents the conventional moment of order l about
         the origin.
 
         PWMs can be applied either when the small observations are more important than the large observations (k=0), as in
         strength properties of materials, or when the large observations should have more influence than the smaller
         observations (k=0) as with three diameter distribution modelling. Here we have chose the former and derived
-        unbiased estimators for moments M_{1,0,k} (j=0), see eq. 16 in [6].
+        unbiased estimators for moments M_{1,0,k} (j=0), see eq. 16 in [6]::
 
-        .. math::
-
-            M_{1,0,k} = \frac{1}{n}\sum_{i=1}^{n}{X_{(i)}\frac{\binom{n-i}{k}}{\binom{n-1}{k}}}
+            M_{1,0,k} = \\frac{1}{n}\\sum_{i=1}^{n}{X_{(i)}\\frac{\\binom{n-i}{k}}{\\binom{n-1}{k}}}
 
         """
         n = float(z.size)

--- a/qats/stats/weibull.py
+++ b/qats/stats/weibull.py
@@ -782,7 +782,7 @@ def mlj(sample, l, j):
 
         M_{l,j,k} = E[X^l * F^j * (1-F)^k]
 
-    , where `X(F)` is the inverse form of the distribution and `F` is the cumulative distribution function.
+    where `X(F)` is the inverse form of the distribution and `F` is the cumulative distribution function.
     When `j=k=0` and `l` is a non-negative integer, then `M_{l,0,0}` represents the conventional moment of order `l`
     about the origin.
 
@@ -799,7 +799,7 @@ def mlj(sample, l, j):
     # todo: include pseudo-code (or Sphinx-friendly LaTex code) for M_{l,j,0} as included below
     '''
     .. math:: M_{l,j,k} = E[X^l F^j (1-F)^k]
-    .. math:: M_{l,j,0} = \frac{1}{n}\sum_{i=j+1}^{n}{X_{(i)}^l\frac{\binom{i-1}{j}}{\binom{n-1}{j}}}
+    .. math:: M_{l,j,0} = \\frac{1}{n}\\sum_{i=j+1}^{n}{X_{(i)}^l\\frac{\\binom{i-1}{j}}{\\binom{n-1}{j}}}
     '''
     n = float(sample.size)
     xi = np.sort(sample)[j:]  # (j+1)th subsample of sorted sample


### PR DESCRIPTION
## What's included in this PR

- [x] Add python 3.13 support, to keep up with the official [Status of Python versions](https://devguide.python.org/versions/).
- [x] Add python 3.13 to test matrix.
- [x] Update python version support info in README.md and documentation. 
        _The documentation now states how to find information about supported python versions, without stating specifically which versions these are. This is to avoid the need to update this information several places when python version support changes._
- [x] Minor docstring improvements to ``qats.signal``, ``qats.fatigue.rainflow`` and ``qats.stats``.

**Edit, 08.01.2025:**

- [ ] Latest release of ``pyside6`` (version 6.8.1.1) breaks installation, because poetry cannot find an installation candidate for ``shiboken6`` version 6.8.1.1 (and ``pyside6`` and ``shiboken6`` version must be identical, ref. https://doc.qt.io/qtforpython-6/shiboken6/gettingstarted.html. A temporary fix is to require ``pyside6 <= 6.8.1`` in ``pyproject.toml``, thereby avoiding version 6.8.1.1. A looser dependency, allowing for ``>=6.8.1``, may be specified when this issue has been fixed on the pyside/shiboken side. This fixes #134.
**Note:** ``shiboken6 6.6.x`` (and therefore ``pyside6 6.6.x``) doesn't seem to work well with ``numpy 2.x``, so it is desirable to allow for ``shiboken6 6.8.x`` also for ``python <=3.12`` instead of restricting the ``numpy`` version more than needed.


To be discussed:

- [ ] Drop support for python 3.8? On one side, it is no longer officially supported according to https://devguide.python.org/versions/. On the other hand, it does not (yet) cause any issues to include support for 3.8. 
**Edit (08.01.2025):** ``poetry`` version 2.0 (latest) requires **python 3.9+**, causing failed tests for **python 3.8** (see https://github.com/dnvgl/qats/actions/runs/12666602368/job/35298567574?pr=133). Options: **1)** drop support for python 3.8, or **2)** ensure in ``test.yaml`` that ``poetry 1.8`` is installed for the python 3.8 tests (not sure if possible), or **3)** specify ``poetry 1.8.5`` in ``test.yaml`` (ref. https://github.com/snok/install-poetry). 
_Currently in favor of option 1 (drop python 3.8 support)._

### Notes

- ``pyproject.toml``: the dependencies under ``tool.poetry.dependencies`` have been updated to work across python versions 3.8 through 3.13. It is probably possible (and certainly desirable) to clean up and simplify the dependency spec, which currently includes quite a few statements like "this version for python <= 3.12, that version for python 3.13", etc. At this stage, however, the main goal has been to ensure that ``poetry install`` works across the supported python versions (and of course, that ``pytest`` and ``qats app`` may thereafter be successfully executed).